### PR TITLE
[Sprint 5] Monitor journey start

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -22,6 +22,32 @@ $govuk-assets-path: '/govuk/assets/';
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
 @import "autoCompleteMultiselects";
 
+.group-by {
+  display: flex;
+
+  .group-by-heading {
+    min-width: 15%;
+  }
+
+  .group-by-links {
+    margin-top: 0;
+    padding-left: 0;
+    align-self: center;
+    width: 100%;
+
+    .govuk-tag a {
+      color: white;
+      text-transform: none;
+      text-decoration: none;
+    }
+  }
+
+  .group-by-link {
+    display: inline-block;
+    margin-right: 5%;
+  }
+}
+
 .govuk-panel--sidebar {
   border-top: $govuk-border-width solid $govuk-brand-colour !important;
   border-left: none !important;

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -103,15 +103,626 @@ module.exports = {
     caseworkers: [
       {
         name: "Liam Johnson",
-        firstName: "Liam"
+        firstName: "Liam",
       },
       {
         name: "Rebecca Green",
-        firstName: "Rebecca"
+        firstName: "Rebecca",
       },
       {
         name: "Jenny Thompson",
-        firstName: "Jenny"
+        firstName: "Jenny",
+      },
+    ],
+  },
+  sprint5: {
+    referrals: [
+      {
+        serviceUser: {
+          name: "Alex River",
+          firstName: "Alex",
+          title: "Mr",
+          gender: "Male",
+          email: "alex.river@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Jessica Reel",
+          email: "j.reel@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Accommodation",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Jenny Thompson",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+          {
+            id: "1",
+            name: "Social inclusion",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Jenny Thompson",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 Sessions (pre-release virtual contact)] Service User has a low risk of reoffending. Service User has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+          {
+            id: "3",
+            name: "Independent living",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Samantha Jones",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Bob Brown",
+          firstName: "Bob",
+          title: "Mr",
+          gender: "Male",
+          email: "bob.brown@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Jessica Reel",
+          email: "j.reel@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Accommodation",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Liam Johnson",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+          {
+            id: "1",
+            name: "Social inclusion",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Rebecca Green",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 Sessions (pre-release virtual contact)] Service User has a low risk of reoffending. Service User has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Emma Thompson",
+          firstName: "Emma",
+          title: "Ms",
+          gender: "Female",
+          email: "emma.thompson@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Josie Bart",
+          email: "j.bart@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Independent living",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Jenny Thompson",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Rosie Palma",
+          firstName: "Rosie",
+          title: "Ms",
+          gender: "Female",
+          email: "rosie.palma@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Claire Phill",
+          email: "c.phill@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Independent living",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Liam Johnson",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Macy Flem",
+          firstName: "Macy",
+          title: "Ms",
+          gender: "Female",
+          email: "macy.flem@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Claire Phill",
+          email: "c.phill@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Social Inclusion",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Rebecca Green",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Robert Watkins",
+          firstName: "Robert",
+          title: "Mr",
+          gender: "Male",
+          email: "robert.watkins@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Claire Phill",
+          email: "c.phill@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Accommodation",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Jenny Thompson",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Mary Moore",
+          firstName: "Mary",
+          title: "Ms",
+          gender: "Female",
+          email: "mary.moore@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Claire Phill",
+          email: "c.phill@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Independent living",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Samantha Jones",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Anthony Hughes",
+          firstName: "Anthony",
+          title: "Mr",
+          gender: "Male",
+          email: "anthony.hughes@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Claire Phill",
+          email: "c.phill@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Social Inclusion",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Rebecca Green",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Fernando Willis",
+          firstName: "Fernando",
+          title: "Mr",
+          gender: "Male",
+          email: "fernando.willis@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Claire Phill",
+          email: "c.phill@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Accommodation",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Jenny Thompson",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Marion Clemmons",
+          firstName: "Marion",
+          title: "Ms",
+          gender: "Female",
+          email: "marion.clemmons@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Claire Phill",
+          email: "c.phill@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Independent living",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Samantha Jones",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Ross Gutierrez",
+          firstName: "Ross",
+          title: "Mr",
+          gender: "Male",
+          email: "ross.g@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Claire Phill",
+          email: "c.phill@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Social Inclusion",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Rebecca Green",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Louis Wing",
+          firstName: "Louis",
+          title: "Mr",
+          gender: "Male",
+          email: "l.wing@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Claire Phill",
+          email: "c.phill@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Accommodation",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Jenny Thompson",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Richard Smith",
+          firstName: "Richard",
+          title: "Mr",
+          gender: "Male",
+          email: "rich@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Claire Phill",
+          email: "c.phill@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Independent living",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Samantha Jones",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Alma Pearson",
+          firstName: "Alma",
+          title: "Ms",
+          gender: "Female",
+          email: "alma.pearson@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Claire Phill",
+          email: "c.phill@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Social Inclusion",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Rebecca Green",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+      {
+        serviceUser: {
+          name: "Natasha Mackey",
+          firstName: "Natasha",
+          title: "Ms",
+          gender: "Female",
+          email: "natasha@gmail.com",
+        },
+        probationPractitioner: {
+          name: "Claire Phill",
+          email: "c.phill@justice.gov.uk",
+        },
+        interventions: [
+          {
+            id: "0",
+            name: "Independent living",
+            providerName: "XYZ Provider Name",
+            assignedCaseworker: "Samantha Jones",
+            actionPlanSubmitted: false,
+            actionPlanApproved: false,
+            assigned: false,
+            goals: [],
+            sessions: [],
+            relevantSentenceHTML:
+              "Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence",
+            desiredOutcomes:
+              "Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.",
+            requiredComplexityHTML:
+              "Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.",
+            completionDateRequired: moment().add("2", "months").toDate(),
+            maximumRARDays: "22",
+            furtherInformation: "N/A",
+          },
+        ],
+      },
+    ].map(createReferralWithoutInterventions),
+    caseworkers: [
+      {
+        name: "Liam Johnson",
+        firstName: "Liam",
+      },
+      {
+        name: "Rebecca Green",
+        firstName: "Rebecca",
+      },
+      {
+        name: "Jenny Thompson",
+        firstName: "Jenny",
+      },
+      {
+        name: "Kelly Clarkson",
+        firstName: "Kelly",
+      },
+      {
+        name: "Samantha Jones",
+        firstName: "Samantha",
       },
     ],
   },
@@ -225,5 +836,67 @@ function createReferral(params, index) {
         furtherInformation: "N/A",
       },
     ],
+  };
+}
+
+function createReferralWithoutInterventions(params, index) {
+  return {
+    reference: "NR" + (index + 1).toString().padStart(4, "0"),
+
+    receivedAt: moment().subtract("1", "days").toDate(),
+
+    serviceUser: Object.assign(
+      {
+        name: "Alex River",
+        firstName: "Alex",
+        otherNames: "Shorty",
+        gender: "Male",
+        title: "Mr",
+        addressHTML:
+          "Flat 2<br>27 Test Walk<br>SY16 1AQ<br><br>Private rental</dd>",
+        nationality: "British",
+        ethnicGroup: "White: British",
+        preferredLanguage: "English",
+        sexuality: "Heterosexual",
+        religionOrBelief: "None",
+        disabilities: "Autism spectrum condition",
+        email: "alex.river@gmail.com",
+        phone: "07588 382 222",
+        pncNumber: "2014/1234786A",
+        crn: "D016868",
+        nomisNumber: "0203394",
+        risks: {
+          OGRSScore: "50",
+          RM2000Score: "Medium",
+          ROSHAScore: "Medium",
+          SARAScore: "Low",
+          scoresInformation: "N/A",
+        },
+        needs: {
+          criminogenicNeeds: [
+            "Thinking and attitudes",
+            "Relationships",
+            "Accommodation",
+          ],
+          identifyNeeds: "N/A",
+          otherNeeds: "N/A",
+          interpreterNeeded: "No",
+          languageNeeds: "English",
+          responsibilities: "Yes",
+          timesUnavailable: "N/A",
+        },
+      },
+      params.serviceUser
+    ),
+    interventions: params.interventions,
+    probationPractitioner: Object.assign(
+      {
+        name: "Jessica Reel",
+        phone: "01909 234 567",
+        email: "j.reel@justice.gov.uk",
+        addressHTML: "44 Bouverie Road<br>Weston Lullingfields<br>SY4 0RE",
+      },
+      params.probationPractitioner
+    ),
   };
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -56,6 +56,8 @@ for (sprint of sprints) {
   );
 }
 
+router.use("/sprint-5/monitor", require("./routes/sprint-5/monitorRoutes"));
+
 async function createAuthenticatedApiClient() {
   const client = new HmppsOffenderAssessmentApi.ApiClient();
 

--- a/app/routes/sprint-5/monitorRoutes.js
+++ b/app/routes/sprint-5/monitorRoutes.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const router = express.Router();
+
+router.get("/cases", (req, res) => {
+  res.render("sprint-5/monitor/cases", {
+    referrals: req.session.data.sprint5.referrals,
+  });
+});
+
+module.exports = router;

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -7,6 +7,11 @@
 {% endfor %}
 
 <script src="/public/javascripts/application.js"></script>
+<script>
+  new MOJFrontend.SortableTable({
+    table: $('table')[0]
+  });
+</script>
 
 {% if useAutoStoreData %}
   <script src="/public/javascripts/auto-store-data.js"></script>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -107,6 +107,18 @@
       </ul>
 
       <h2 class="govuk-heading-l">
+        Sprint 5
+      </h2>
+      <ul class="govuk-list">
+        <a href="sprint-5/monitor/cases" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8" data-module="govuk-button">
+          Monitor a service user's progress
+          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewbox="0 0 33 40" role="presentation" focusable="false">
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+          </svg>
+        </a>
+      </ul>
+
+      <h2 class="govuk-heading-l">
         Technical demos
       </h2>
       <ul class="govuk-list">

--- a/app/views/sprint-5/monitor/cases.html
+++ b/app/views/sprint-5/monitor/cases.html
@@ -4,6 +4,11 @@
   Manage interventions and services
 {% endblock %}
 
+{% block header %}
+  {{ super() }}
+  {% include "./includes/primary-navigation.html" %}
+{% endblock %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column">

--- a/app/views/sprint-5/monitor/cases.html
+++ b/app/views/sprint-5/monitor/cases.html
@@ -16,61 +16,65 @@
         My cases
       </h1>
     </div>
+    <div class="group-by">
+      <h2 class="govuk-heading-m group-by-heading">
+        Group by:
+      </h2>
+      <ul class="group-by-links">
+        <li class="group-by-link govuk-tag">
+          <a aria-current="page" href="cases">Details</a>
+        </li>
+        <li class="group-by-link">
+          <a href="stages">Stages</a>
+        </li>
+      </ul>
+    </div>
+  </div>
 
-    <table class="govuk-table">
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header" aria-sort="ascending">Referral</th>
+        <th scope="col" class="govuk-table__header" aria-sort="none">Service User</th>
+        <th scope="col" class="govuk-table__header" aria-sort="none">Intervention category</th>
+        <th scope="col" class="govuk-table__header" aria-sort="none">Provider</th>
+        <th scope="col" class="govuk-table__header" aria-sort="none">Caseworker</th>
+        <th scope="col" class="govuk-table__header" aria-sort="none">Action</th>
+      </tr>
+    </thead>
 
-      <thead class="govuk-table__head">
+    <tbody class="govuk-table__body">
+      {% for referral in referrals %}
+        {% set referralIndex = loop.index0 %}
         <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header" aria-sort="ascending">Referral</th>
-          <th scope="col" class="govuk-table__header" aria-sort="none">Service User</th>
-          <th scope="col" class="govuk-table__header" aria-sort="none">Intervention category</th>
-          <th scope="col" class="govuk-table__header" aria-sort="none">Provider</th>
-          <th scope="col" class="govuk-table__header" aria-sort="none">Caseworker</th>
-          <th scope="col" class="govuk-table__header" aria-sort="none">Action</th>
+          <td class="govuk-table__cell" rowspan="{{referral.interventions.length}}">
+            {{ referral.reference }}
+          </td>
+          <td class="govuk-table__cell" rowspan="{{referral.interventions.length}}">
+            {{ referral.serviceUser.name }}
+          </td>
+
+          {% for intervention in referral.interventions %}
+            <td class="govuk-table__cell">
+              {{ intervention.name | capitalize }}
+            </td>
+            <td class="govuk-table__cell">
+              {{ intervention.providerName }}
+            </td>
+            <td class="govuk-table__cell">
+              {{ intervention.assignedCaseworker }}
+            </td>
+            <td class="govuk-table__cell">
+              <a class="govuk-link" href="cases/{{caseIndex}}/interventions/{{intervention.id}}">View</a>
+            </td>
+
+            {% if referral.interventions.length > 1 and not loop.last %}
+            </tr>
+            {% endif%}
+
+          {% endfor %}
         </tr>
-      </thead>
-
-      <tbody class="govuk-table__body">
-        {% for referral in referrals %}
-          {% set referralIndex = loop.index0 %}
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell" rowspan="{{referral.interventions.length}}">
-              {{ referral.reference }}
-            </td>
-            <td class="govuk-table__cell" rowspan="{{referral.interventions.length}}">
-              {{ referral.serviceUser.name }}
-            </td>
-
-            {% for intervention in referral.interventions %}
-              <td class="govuk-table__cell">
-                {{ intervention.name | capitalize }}
-              </td>
-              <td class="govuk-table__cell">
-                {{ intervention.providerName }}
-              </td>
-              <td class="govuk-table__cell">
-                {{ intervention.assignedCaseworker }}
-              </td>
-              <td class="govuk-table__cell">
-                <a class="govuk-link" href="cases/{{caseIndex}}/interventions/{{intervention.id}}">View</a>
-              </td>
-
-              {% if referral.interventions.length > 1 and not loop.last %}
-              </tr>
-              {% endif%}
-
-            {% endfor %}
-          </tr>
-        {% endfor %}
-      </tbody>
-
-      {# <tr class="govuk-table__row">
-          <td class="govuk-table__cell">Denali</td>
-          <td class="govuk-table__cell" data-sort-value="6194">6,194 meters</td>
-          <td class="govuk-table__cell">North America</td>
-          <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="1913">1913</td>
-        </tr> #}
-
+      {% endfor %}
     </tbody>
   </table>
 </div>

--- a/app/views/sprint-5/monitor/cases.html
+++ b/app/views/sprint-5/monitor/cases.html
@@ -1,0 +1,72 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Manage interventions and services
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column">
+      <h1 class="govuk-heading-xl">
+        My cases
+      </h1>
+    </div>
+
+    <table class="govuk-table">
+
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header" aria-sort="ascending">Referral</th>
+          <th scope="col" class="govuk-table__header" aria-sort="none">Service User</th>
+          <th scope="col" class="govuk-table__header" aria-sort="none">Intervention category</th>
+          <th scope="col" class="govuk-table__header" aria-sort="none">Provider</th>
+          <th scope="col" class="govuk-table__header" aria-sort="none">Caseworker</th>
+          <th scope="col" class="govuk-table__header" aria-sort="none">Action</th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+        {% for referral in referrals %}
+          {% set referralIndex = loop.index0 %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell" rowspan="{{referral.interventions.length}}">
+              {{ referral.reference }}
+            </td>
+            <td class="govuk-table__cell" rowspan="{{referral.interventions.length}}">
+              {{ referral.serviceUser.name }}
+            </td>
+
+            {% for intervention in referral.interventions %}
+              <td class="govuk-table__cell">
+                {{ intervention.name | capitalize }}
+              </td>
+              <td class="govuk-table__cell">
+                {{ intervention.providerName }}
+              </td>
+              <td class="govuk-table__cell">
+                {{ intervention.assignedCaseworker }}
+              </td>
+              <td class="govuk-table__cell">
+                <a class="govuk-link" href="cases/{{caseIndex}}/interventions/{{intervention.id}}">View</a>
+              </td>
+
+              {% if referral.interventions.length > 1 and not loop.last %}
+              </tr>
+              {% endif%}
+
+            {% endfor %}
+          </tr>
+        {% endfor %}
+      </tbody>
+
+      {# <tr class="govuk-table__row">
+          <td class="govuk-table__cell">Denali</td>
+          <td class="govuk-table__cell" data-sort-value="6194">6,194 meters</td>
+          <td class="govuk-table__cell">North America</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="1913">1913</td>
+        </tr> #}
+
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/app/views/sprint-5/monitor/includes/primary-navigation.html
+++ b/app/views/sprint-5/monitor/includes/primary-navigation.html
@@ -1,0 +1,16 @@
+<div class="moj-primary-navigation">
+  <div class="moj-primary-navigation__container">
+    <div class="moj-primary-navigation__nav">
+      <nav class="moj-primary-navigation" aria-label="Primary navigation">
+        <ul class="moj-primary-navigation__list">
+          <li class="moj-primary-navigation__item">
+            <a class="moj-primary-navigation__link" aria-current="page" href="">My cases</a>
+          </li>
+          <li class="moj-primary-navigation__item">
+            <a class="moj-primary-navigation__link" href="notifications">My notifications</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Changes in this PR

- Adds lots more data to for sprint 5 (15 service users with unique intervention types and more variety).
- Add "My cases page" for start of monitor journey.

Not all links work, and the table sorting doesn't quite work either, but I wanted to get this merged early to give Lawrence the directory to work in and the start of the journey.

## Screenshots

### My cases
![image](https://user-images.githubusercontent.com/19826940/95106949-25913f80-0731-11eb-9329-5cb0c887c636.png)
