### PR TITLE
Git ignore Assessments API Client node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@ lib/extensions/_extensions.scss
 .start.pid
 .port.tmp
 public
-node_modules/*
+node_modules/
 .tmuxp.*
 package-lock.json


### PR DESCRIPTION
This keeps popping up in my git history so it'd be nice to gitignore it.