### PR TITLE
A caseworker can terminate an intervention

### DIFF
--- a/app/routes/sprint-5/caseworkerManageRoutes.js
+++ b/app/routes/sprint-5/caseworkerManageRoutes.js
@@ -247,13 +247,24 @@ router.get("/referrals/:referralIndex/interventions/:interventionIndex/fast-forw
     res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
 });
 
+router.get(`/referrals/:referralIndex/interventions/:interventionIndex/end-of-service-report`, (req, res) => {
+    const intervention = findIntervention(req);
+    const referral = findReferral(req);
+
+    const isTermination = req.query.termination === "true";
+
+    res.render(`sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report`, { intervention, referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex, referral, isTermination });
+});
+
 router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-service-report-check-answers", (req, res) => {
     const intervention = findIntervention(req);
     const referral = findReferral(req);
 
+    const isTermination = req.body.terminated === "true";
+
     endOfServiceReport = req.body;
 
-    res.render("sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report-check-answers", { referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex, intervention, referral, endOfServiceReport });
+    res.render("sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report-check-answers", { referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex, intervention, referral, endOfServiceReport, isTermination });
 });
 
 router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-service-report-reason", (req, res) => {
@@ -275,7 +286,7 @@ router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-s
 router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-service-report-contacted-probation-practitioner", (req, res) => {
     switch (req.body["contacted-probation-practitioner"]) {
 	case "yes":
-	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report`);
+	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report?termination=true`);
 	    break;
 	case "no":
 	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report-contact-probation-practitioner`);
@@ -291,7 +302,10 @@ router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-s
 router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-service-report", (req, res) => {
     const intervention = findIntervention(req);
 
-    intervention.endOfServiceReport = req.body;
+    const endOfServiceReport = req.body;
+    endOfServiceReport.terminated = (endOfServiceReport.terminated === "true");
+
+    intervention.endOfServiceReport = endOfServiceReport;
     intervention.endOfServiceReportSubmittedAt = new Date();
 
     res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report-confirmation`);

--- a/app/routes/sprint-5/caseworkerManageRoutes.js
+++ b/app/routes/sprint-5/caseworkerManageRoutes.js
@@ -278,7 +278,7 @@ router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-s
 	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report`);
 	    break;
 	case "no":
-	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report`);
+	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report-contact-probation-practitioner`);
 	    break;
 	default:
 	    // Not building validation into the prototype, so just ask the
@@ -319,7 +319,7 @@ router.post("/referrals/:referralIndex/interventions/:interventionIndex/initial-
     res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
 });
 
-for (const page of ["probation-practitioner-email-confirmation", "send-email", "upload-case-notes", "communication-archive", "casenotes-upload-confirmation", "end-of-service-report", "end-of-service-report-check-your-answers", "end-of-service-report-reason", "end-of-service-report-contacted-probation-practitioner"]) {
+for (const page of ["probation-practitioner-email-confirmation", "send-email", "upload-case-notes", "communication-archive", "casenotes-upload-confirmation", "end-of-service-report", "end-of-service-report-check-your-answers", "end-of-service-report-reason", "end-of-service-report-contacted-probation-practitioner", "end-of-service-report-contact-probation-practitioner"]) {
     router.get(`/referrals/:referralIndex/interventions/:interventionIndex/${page}`, (req, res) => {
 	const intervention = findIntervention(req);
 	const referral = findReferral(req);

--- a/app/routes/sprint-5/caseworkerManageRoutes.js
+++ b/app/routes/sprint-5/caseworkerManageRoutes.js
@@ -247,13 +247,6 @@ router.get("/referrals/:referralIndex/interventions/:interventionIndex/fast-forw
     res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
 });
 
-router.get("/referrals/:referralIndex/interventions/:interventionIndex/end-of-service-report", (req, res) => {
-    const intervention = findIntervention(req);
-    const referral = findReferral(req);
-
-    res.render("sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report", { referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex, intervention, referral });
-});
-
 router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-service-report-check-answers", (req, res) => {
     const intervention = findIntervention(req);
     const referral = findReferral(req);
@@ -261,6 +254,22 @@ router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-s
     endOfServiceReport = req.body;
 
     res.render("sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report-check-answers", { referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex, intervention, referral, endOfServiceReport });
+});
+
+router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-service-report-reason", (req, res) => {
+    switch (req.body.reason) {
+	case "delivered-successfully":
+	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report`);
+	    break;
+	case "termination":
+	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report`);
+	    break;
+	default:
+	    // Not building validation into the prototype, so just ask the
+	    // question again.
+	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report-contacted-probation-practitioner`);
+	    break;
+    }
 });
 
 router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-service-report", (req, res) => {
@@ -294,7 +303,7 @@ router.post("/referrals/:referralIndex/interventions/:interventionIndex/initial-
     res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
 });
 
-for (const page of ["probation-practitioner-email-confirmation", "send-email", "upload-case-notes", "communication-archive", "casenotes-upload-confirmation"]) {
+for (const page of ["probation-practitioner-email-confirmation", "send-email", "upload-case-notes", "communication-archive", "casenotes-upload-confirmation", "end-of-service-report", "end-of-service-report-check-your-answers", "end-of-service-report-reason"]) {
     router.get(`/referrals/:referralIndex/interventions/:interventionIndex/${page}`, (req, res) => {
 	const intervention = findIntervention(req);
 	const referral = findReferral(req);

--- a/app/routes/sprint-5/caseworkerManageRoutes.js
+++ b/app/routes/sprint-5/caseworkerManageRoutes.js
@@ -28,7 +28,9 @@ function findReferralByIndex(req, index) {
 
     for (const intervention of referral.interventions) {
 	// Populate the intervention’s status based on which events have occurred.
-	if (intervention.initialAssessment == null) {
+	if (intervention.endOfServiceReport != null && intervention.endOfServiceReport.terminated) {
+	    intervention.status = "terminated";
+	} else if (intervention.initialAssessment == null) {
 	    intervention.status = "not started";
 	} else if (intervention.endOfServiceReport == null) {
 	    intervention.status = "in progress";
@@ -74,12 +76,17 @@ function findReferralByIndex(req, index) {
 	// Populate end of service report status.
 	if (intervention.endOfServiceReport == null) {
 	    intervention.endOfServiceReportStatus = "not started";
+	} else if (intervention.endOfServiceReport.terminated) {
+	    intervention.endOfServiceReportStatus = "terminated";
 	} else {
 	    intervention.endOfServiceReportStatus = "completed";
 	}
 
 	// Populate delivery progress based on which events have occurred.
-	if (intervention.sessions.some(session => session.assessment != null)) {
+	if (intervention.endOfServiceReport != null && intervention.endOfServiceReport.terminated) {
+	    intervention.deliveryProgress = "terminated";
+	}
+	else if (intervention.sessions.some(session => session.assessment != null)) {
 	    if (intervention.sessions.every(session => session.assessment != null) && intervention.endOfServiceReport != null) {
 		intervention.deliveryProgress = "completed";
 	    } else {
@@ -136,6 +143,8 @@ function cssClassForEndOfServiceReportStatus(endOfServiceReportStatus) {
     switch (endOfServiceReportStatus) {
 	case "completed":
 	    return "govuk-tag";
+	case "terminated":
+	    return "govuk-tag govuk-tag--red";
 	default:
 	    return "govuk-tag govuk-tag--grey";
     }

--- a/app/routes/sprint-5/caseworkerManageRoutes.js
+++ b/app/routes/sprint-5/caseworkerManageRoutes.js
@@ -262,6 +262,22 @@ router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-s
 	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report`);
 	    break;
 	case "termination":
+	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report-contacted-probation-practitioner`);
+	    break;
+	default:
+	    // Not building validation into the prototype, so just ask the
+	    // question again.
+	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report-reason`);
+	    break;
+    }
+});
+
+router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-service-report-contacted-probation-practitioner", (req, res) => {
+    switch (req.body["contacted-probation-practitioner"]) {
+	case "yes":
+	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report`);
+	    break;
+	case "no":
 	    res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report`);
 	    break;
 	default:
@@ -303,7 +319,7 @@ router.post("/referrals/:referralIndex/interventions/:interventionIndex/initial-
     res.redirect(`/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
 });
 
-for (const page of ["probation-practitioner-email-confirmation", "send-email", "upload-case-notes", "communication-archive", "casenotes-upload-confirmation", "end-of-service-report", "end-of-service-report-check-your-answers", "end-of-service-report-reason"]) {
+for (const page of ["probation-practitioner-email-confirmation", "send-email", "upload-case-notes", "communication-archive", "casenotes-upload-confirmation", "end-of-service-report", "end-of-service-report-check-your-answers", "end-of-service-report-reason", "end-of-service-report-contacted-probation-practitioner"]) {
     router.get(`/referrals/:referralIndex/interventions/:interventionIndex/${page}`, (req, res) => {
 	const intervention = findIntervention(req);
 	const referral = findReferral(req);

--- a/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report-check-answers.html
+++ b/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report-check-answers.html
@@ -60,6 +60,15 @@
 
       <form method="post" action="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/end-of-service-report">
 
+        {% if isTermination %}
+          <h2 class="govuk-heading-l">
+            Reason for termination
+          </h2>
+
+          <p class="govuk-body">{{ endOfServiceReport["termination-short-reason"] }}</p>
+          <p class="govuk-body">{{ endOfServiceReport["termination-reason"] }}</p>
+        {% endif %}
+
         {% for goal in intervention.goals %}
           {% set name = "goal-" + loop.index0 %}
           {% set detailsName = "goal-" + loop.index0 + "-details" %}

--- a/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report-contact-probation-practitioner.html
+++ b/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report-contact-probation-practitioner.html
@@ -1,0 +1,50 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  End of service report
+{% endblock %}
+
+{% block header %}
+  {{ super() }}
+  {% include "../includes/referral-header.html" %}
+{% endblock %}
+
+{% block beforeContent %}
+  <a href="javascript: window.history.go(-1)" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        Contact the probation practitioner before terminating the service
+      </h1>
+
+      <p class="govuk-body">
+      You can contact the probation practitioner by either:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li><a href="send-email" class="govuk-link">sending an email to the probation practitioner</a></li>
+        <li>contacting by telephone on {{ referral.probationPractitioner.phone }}</li>
+      </ul>
+
+      <p class="govuk-body">
+      <a class="govuk-link" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}">Back to {{ referral.serviceUser.firstName }}’s referral page</a>
+      </p>
+    </div>
+
+    <div class="govuk-grid-column-one-third govuk-panel govuk-panel--sidebar">
+      <h2>Subsection</h2>
+      <p>
+      <a class="govuk-link" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/send-email">Send email to probation practitioner</a>
+      </p>
+      <p>
+      <a class="govuk-link" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/upload-case-notes">Add case notes</a>
+      </p>
+      <p>
+      <a class="govuk-link" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/communication-archive">View communication history</a>
+      </p>
+    </div>
+
+  </div>
+{% endblock %}

--- a/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report-contacted-probation-practitioner.html
+++ b/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report-contacted-probation-practitioner.html
@@ -1,0 +1,62 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  End of service report
+{% endblock %}
+
+{% block header %}
+  {{ super() }}
+  {% include "../includes/referral-header.html" %}
+{% endblock %}
+
+{% block beforeContent %}
+  <a href="javascript: window.history.go(-1)" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form method="post">
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+              <h1 class="govuk-fieldset__heading">
+                Did you let the probation practitioner know that you are about to terminate the service?
+              </h1>
+            </legend>
+            <div class="govuk-radios">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="contacted-probation-practitioner-yes" name="contacted-probation-practitioner" type="radio" value="yes">
+                <label class="govuk-label govuk-radios__label" for="contacted-probation-practitioner-yes">
+                  Yes
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="contacted-probation-practitioner-no" name="contacted-probation-practitioner" type="radio" value="no">
+                <label class="govuk-label govuk-radios__label" for="contacted-probation-practitioner-no">
+                  No, I need to contact them
+                </label>
+              </div>
+            </div>
+
+          </fieldset>
+        </div>
+        <input type="submit" class="govuk-button" data-module="govuk-button" value="Continue">
+      </form>
+    </div>
+
+    <div class="govuk-grid-column-one-third govuk-panel govuk-panel--sidebar">
+      <h2>Subsection</h2>
+      <p>
+      <a class="govuk-link" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/send-email">Send email to probation practitioner</a>
+      </p>
+      <p>
+      <a class="govuk-link" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/upload-case-notes">Add case notes</a>
+      </p>
+      <p>
+      <a class="govuk-link" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/communication-archive">View communication history</a>
+      </p>
+    </div>
+
+  </div>
+{% endblock %}

--- a/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report-reason.html
+++ b/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report-reason.html
@@ -1,0 +1,58 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  End of service report
+{% endblock %}
+
+{% block header %}
+  {{ super() }}
+  {% include "../includes/referral-header.html" %}
+{% endblock %}
+
+{% block beforeContent %}
+  <a href="javascript: window.history.go(-1)" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">End of service report</h1>
+
+      <p class="govuk-body">
+      On this page you can:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>create an end of service report for a completed intervention</li>
+        <li>create an end of service report for a terminated intervention</li>
+      </ul>
+
+      <form method="post">
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+              <h2 class="govuk-fieldset__heading">
+                What is the reason for ending this service?
+              </h2>
+            </legend>
+            <div class="govuk-radios">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="reason-delivered-successfully" name="reason" type="radio" value="delivered-successfully">
+                <label class="govuk-label govuk-radios__label" for="reason-delivered-successfully">
+                  The action plan has been delivered successfully / intervention delivered successfully
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="reason-termination" name="reason" type="radio" value="termination">
+                <label class="govuk-label govuk-radios__label" for="reason-termination">
+                  The intervention is being terminated
+                </label>
+              </div>
+            </div>
+
+          </fieldset>
+        </div>
+        <input type="submit" class="govuk-button" data-module="govuk-button" value="Continue">
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report.html
+++ b/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/end-of-service-report.html
@@ -60,6 +60,32 @@
 
       <form method="post" action="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/end-of-service-report-check-answers">
 
+        {% if isTermination %}
+          <h2 class="govuk-heading-m">
+            Reason for termination
+          </h2>
+
+          <p class="govuk-body">
+          As a service provider you can terminate the service at any time. Please provide details below.
+          </p>
+
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="termination-short-reason">
+              Brief detail
+            </label>
+            <input class="govuk-input" id="termination-short-reason" name="termination-short-reason">
+          </div>
+
+          <input type="hidden" name="terminated" value="true">
+
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="termination-reason">
+              Reason for termination
+            </label>
+            <textarea class="govuk-textarea" id="termination-reason" name="termination-reason"></textarea>
+          </div>
+        {% endif %}
+
         {% for goal in intervention.goals %}
           <div class="govuk-form-group">
             <fieldset class="govuk-fieldset">

--- a/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/includes/intervention/end-of-service-report.html
+++ b/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/includes/intervention/end-of-service-report.html
@@ -10,7 +10,7 @@
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">{{ referral.probationPractitioner.name }}</td>
       <td class="govuk-table__cell"><strong class="{{ cssClassForEndOfServiceReportStatus(intervention.endOfServiceReportStatus) }}">{{ intervention.endOfServiceReportStatus }}</strong></td>
-      {% if intervention.endOfServiceReportStatus === "completed" %}
+      {% if intervention.endOfServiceReportStatus === "completed" or intervention.endOfServiceReportStatus === "terminated" %}
         <td class="govuk-table__cell"><a class="govuk-link" href="#">View</a></td>
       {% else %}
         <td class="govuk-table__cell"><a class="govuk-link" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/end-of-service-report-reason">Start</a></td>

--- a/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/includes/intervention/end-of-service-report.html
+++ b/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/includes/intervention/end-of-service-report.html
@@ -13,7 +13,7 @@
       {% if intervention.endOfServiceReportStatus === "completed" %}
         <td class="govuk-table__cell"><a class="govuk-link" href="#">View</a></td>
       {% else %}
-        <td class="govuk-table__cell"><a class="govuk-link" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/end-of-service-report">Start</a></td>
+        <td class="govuk-table__cell"><a class="govuk-link" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/end-of-service-report-reason">Start</a></td>
       {% endif %}
     </tr>
   </tbody>

--- a/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/intervention.html
+++ b/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/intervention.html
@@ -116,23 +116,15 @@
 	    </p>
 	    {% if showProgress %}
 	      {% include "./includes/intervention/progress.html" %}
-
-	      <h2 class="govuk-heading-l">End of service report</h2>
-	      {% set showEndOfServiceReport = allSessionsAssessed %}
-	      <p class="govuk-body">
-	      Complete and submit the end of service report.
-	      {% if not showEndOfServiceReport %}
-		Interventions ready for an end of service report will appear below once the post-session feedback forms of the intervention are completed.
-	      {% endif %}
-	      </p>
-	      {% if showEndOfServiceReport %}
-		{% include "./includes/intervention/end-of-service-report.html" %}
-	      {% endif %}
-
 	    {% endif %}
 
 	  {% endif %}
 
+	  <h2 class="govuk-heading-l">End of service report</h2>
+	  <p class="govuk-body">
+	  Complete and submit the end of service report when the service user has met the conditions for this intervention. If the service user has not met the conditions of the intervention the service provider can also terminate and generate an end of service report at any time.
+	  </p>
+	  {% include "./includes/intervention/end-of-service-report.html" %}
 	</div>
 
 	<div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="referral-details">

--- a/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals.html
+++ b/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals.html
@@ -52,7 +52,7 @@
 	    {% set referralIndex = loop.index0 %}
 	    {{ interventionIndexesByReferral.push([]) and null }}
 	    {% for intervention in referral.interventions %}
-	      {% if intervention.initialAssessmentStatus === "not scheduled" %}
+	      {% if intervention.status !== "terminated" and intervention.initialAssessmentStatus === "not scheduled" %}
 		{% set hasReferrals = true %}
 		{{ interventionIndexesByReferral[referralIndex].push(loop.index0) and null }}
 	      {% endif %}
@@ -108,7 +108,7 @@
 	    {% set referralIndex = loop.index0 %}
 	    {{ interventionIndexesByReferral.push([]) and null }}
 	    {% for intervention in referral.interventions %}
-	      {% if intervention.initialAssessmentStatus === "scheduled" and intervention.actionPlanStatus === "not submitted" %}
+	      {% if intervention.initialAssessmentStatus === "scheduled" and intervention.actionPlanStatus === "not submitted" and intervention.status !== "terminated" %}
 		{% set hasReferrals = true %}
 		{{ interventionIndexesByReferral[referralIndex].push(loop.index0) and null }}
 	      {% endif %}
@@ -288,8 +288,7 @@
 	    {% set referralIndex = loop.index0 %}
 	    {{ interventionIndexesByReferral.push([]) and null }}
 	    {% for intervention in referral.interventions %}
-	      {# TODO Not sure of the logic for a ”breach”, so we’re just showing all the referrals for now #}
-	      {% if true %}
+	      {% if intervention.status === "terminated" %}
 		{% set hasReferrals = true %}
 		{{ interventionIndexesByReferral[referralIndex].push(loop.index0) and null }}
 	      {% endif %}
@@ -305,7 +304,7 @@
 		  <th scope="col" class="govuk-table__header">Service user</th>
 		  <th scope="col" class="govuk-table__header">Probation practitioner</th>
 		  <th scope="col" class="govuk-table__header">Intervention</th>
-		  <th scope="col" class="govuk-table__header">Reason for breach</th>
+		  <th scope="col" class="govuk-table__header">Reason for termination</th>
 		  <th scope="col" class="govuk-table__header">Action</th>
 		</tr>
 	      </thead>
@@ -327,7 +326,7 @@
 			{% endif %}
 
 			<td class="govuk-table__cell">{{ intervention.name }}</td>
-			<td class="govuk-table__cell"></td>
+			<td class="govuk-table__cell">{{ intervention.endOfServiceReport["termination-short-reason"] }}</td>
 			<td class="govuk-table__cell"><a href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{loop.index0}}">View</a></td>
 		      </tr>
 		    {% endif %}


### PR DESCRIPTION
# What's new

A caseworker can now end an intervention at any time, by "terminating" it. When they terminate an intervention, they have to fill in an end of service report, providing detail about why they're terminating.

We now use these terminated interventions to populate the "terminated interventions" tab on the dashboard.

# What's next

- Decide logic around when caseworker is allowed to do a "successful" end of service report [(Trello)](https://trello.com/c/ALezeHz8/391-is-there-still-some-logic-around-all-sessions-assessed-figma-commenthttps-wwwfigmacom-file-29ggwjrjwnrv8tvvzoqkvinode-id12754869)
- Decide which actions and sections are available once the intervention has been terminated [(Trello)](https://trello.com/c/FHtJlh1y/392-what-actions-and-sections-are-available-once-the-intervention-has-been-terminated)

# Screenshots

![image](https://user-images.githubusercontent.com/53756884/95302156-7744e180-0879-11eb-898b-a344a93afb6d.png)
![image](https://user-images.githubusercontent.com/53756884/95302187-80ce4980-0879-11eb-85ef-d32fa8058bd8.png)
![image](https://user-images.githubusercontent.com/53756884/95302209-89268480-0879-11eb-8e59-23d35460a783.png)
![image](https://user-images.githubusercontent.com/53756884/95302313-b2471500-0879-11eb-9002-e162880f5a6a.png)
![image](https://user-images.githubusercontent.com/53756884/95302350-c0953100-0879-11eb-9df6-5b5e594196bd.png)
![image](https://user-images.githubusercontent.com/53756884/95302384-cbe85c80-0879-11eb-9f86-96f3f02812fa.png)
![image](https://user-images.githubusercontent.com/53756884/95302414-d3a80100-0879-11eb-8f10-5fd0ccc9efac.png)
