### PR TITLE
Move fast-forward links into sidebar

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -107,10 +107,11 @@ $govuk-assets-path: '/govuk/assets/';
 }
 
 .govuk-link--app-fast-forward {
-  border: 1px solid red;
-  padding: 3px;
-  color: red;
-  font-weight: bold;
+  color: govuk-colour("pink") !important;
+
+  &:visited {
+    color: govuk-colour("pink") !important;
+  }
 }
 
 // TODO This didn’t work with the class there only once (just uses the 960px of

--- a/app/routes/sprint-5/caseworkerManageRoutes.js
+++ b/app/routes/sprint-5/caseworkerManageRoutes.js
@@ -207,9 +207,9 @@ router.get("/referrals/:referralIndex/interventions/:interventionIndex", (req, r
     // "scheduled" status, which is still considered a to-do task)
 
     const showInitialAssessment = true;
-    const populateInitialAssessmentContent = true;
+    viewModel.populateInitialAssessmentContent = true;
     if (showInitialAssessment) {
-	const section = { id: "initialAssessment", populateContent: populateInitialAssessmentContent }
+	const section = { id: "initialAssessment", populateContent: viewModel.populateInitialAssessmentContent }
 
 	const isTaskCompleted = intervention.initialAssessmentStatus === "delivered";
 	if (isTaskCompleted) {
@@ -219,12 +219,12 @@ router.get("/referrals/:referralIndex/interventions/:interventionIndex", (req, r
 	}
     }
 
-    const showActionPlan = populateInitialAssessmentContent;
-    const populateActionPlanContent = intervention.initialAssessmentStatus === "delivered";
+    const showActionPlan = viewModel.populateInitialAssessmentContent;
+    viewModel.populateActionPlanContent = intervention.initialAssessmentStatus === "delivered";
     if (showActionPlan) {
-	const section = { id: "actionPlan", populateContent: populateActionPlanContent };
+	const section = { id: "actionPlan", populateContent: viewModel.populateActionPlanContent };
 
-	const isTaskCompleted = populateActionPlanContent && intervention.actionPlanStatus === "approved";
+	const isTaskCompleted = viewModel.populateActionPlanContent && intervention.actionPlanStatus === "approved";
 	if (isTaskCompleted) {
 	    viewModel.completedTasksSections.push(section);
 	} else {
@@ -232,12 +232,12 @@ router.get("/referrals/:referralIndex/interventions/:interventionIndex", (req, r
 	}
     }
 
-    const showInterventionSessions = populateActionPlanContent;
-    const populateInterventionSessionsContent = intervention.actionPlanStatus === "approved";
+    const showInterventionSessions = viewModel.populateActionPlanContent;
+    viewModel.populateInterventionSessionsContent = intervention.actionPlanStatus === "approved";
     if (showInterventionSessions) {
-	const section = { id: "interventionSessions", populateContent: populateInterventionSessionsContent };
+	const section = { id: "interventionSessions", populateContent: viewModel.populateInterventionSessionsContent };
 
-	const isTaskCompleted = populateInterventionSessionsContent && intervention.sessionsStatus === "completed";
+	const isTaskCompleted = viewModel.populateInterventionSessionsContent && intervention.sessionsStatus === "completed";
 	if (isTaskCompleted) {
 	    viewModel.completedTasksSections.push(section);
 	} else {
@@ -246,9 +246,9 @@ router.get("/referrals/:referralIndex/interventions/:interventionIndex", (req, r
     }
 
     const showEndOfServiceReport = true;
-    const populateEndOfServiceReportContent = true;
+    viewModel.populateEndOfServiceReportContent = true;
     if (showEndOfServiceReport) {
-	const section = { id: "endOfServiceReport", populateContent: populateEndOfServiceReportContent };
+	const section = { id: "endOfServiceReport", populateContent: viewModel.populateEndOfServiceReportContent };
 
 	const isTaskCompleted = ["completed", "terminated"].includes(intervention.endOfServiceReportStatus);
 	if (isTaskCompleted) {

--- a/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/includes/intervention/action-plan.html
+++ b/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/includes/intervention/action-plan.html
@@ -30,9 +30,3 @@
     </dd>
   </div>
 </dl>
-
-{% if intervention.actionPlanStatus === "pending approval" %}
-  <p class="govuk-body">
-  <a class="govuk-link govuk-link--app-fast-forward" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/action-plan-approved">Fast-forward to action plan approved</a>
-  </p>
-{% endif %}

--- a/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/includes/intervention/progress.html
+++ b/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/includes/intervention/progress.html
@@ -29,9 +29,3 @@
     </tr>
   {% endfor %}
 </table>
-
-{% if not allSessionsAssessed %}
-  <p class="govuk-body">
-  <a class="govuk-link govuk-link--app-fast-forward" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/sessions-completed">Fast-forward to sessions completed</a>
-  </p>
-{% endif %}

--- a/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/intervention.html
+++ b/app/views/sprint-5/book-and-manage/manage-a-referral/caseworker/intervention.html
@@ -60,6 +60,17 @@
       <p>
       <a class="govuk-link" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/communication-archive">View communication history</a>
       </p>
+      {% if viewModel.populateInterventionSessionsContent and not allSessionsAssessed %}
+	<p>
+	<a class="govuk-link govuk-link--app-fast-forward" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/sessions-completed">User research example: fast-forward to sessions completed</a>
+	</p>
+      {% endif %}
+
+      {% if viewModel.populateActionPlanContent and intervention.actionPlanStatus === "pending approval" %}
+	<p class="govuk-body">
+	<a class="govuk-link govuk-link--app-fast-forward" href="/sprint-5/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/action-plan-approved">User research example: fast-forward to action plan approved</a>
+	</p>
+      {% endif %}
     </div>
 
   </div>


### PR DESCRIPTION
# What's new

Some research participants have got confused by the fast-forward links, thinking they’re part of the journey. Move them to the sidebar, colour them consistently, put "User research example:" in front of them to make it clear why they’re there.

# Screenshot

![image](https://user-images.githubusercontent.com/53756884/95846653-980eaa80-0d43-11eb-93bd-b59579bbccef.png)



