### PR TITLE
Sprint 6 - Monitor: Add Action Plan approval page

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -52,6 +52,12 @@ $govuk-assets-path: '/govuk/assets/';
   padding: 0 !important;
 }
 
+.conditional-section {
+  margin-left: 0 !important;
+  padding-left: 0 !important;
+  border-left: none !important;
+}
+
 .govuk-panel--sidebar {
   border-top: $govuk-border-width solid $govuk-brand-colour !important;
   border-left: none !important;

--- a/app/routes/sprint-6/monitorRoutes.js
+++ b/app/routes/sprint-6/monitorRoutes.js
@@ -147,4 +147,61 @@ router.get(
   }
 );
 
+router.get(
+  "/cases/:referralNumber/interventions/:interventionId/action-plan",
+  (req, res) => {
+    const referralNumber = req.params.referralNumber;
+    const interventionId = req.params.interventionId;
+
+    const referral = findReferral(
+      req.session.data.sprint6.referrals,
+      referralNumber
+    );
+
+    const intervention = referral.interventions.find(
+      (intervention) => interventionId === intervention.id
+    );
+
+    const serviceUser = referral ? referral.serviceUser : {};
+
+    res.render("sprint-6/monitor/cases/action-plan-review", {
+      referral: referral,
+      intervention: intervention,
+      serviceUser: serviceUser,
+      currentPage: intervention.name,
+    });
+  }
+);
+
+router.post(
+  "/cases/:referralNumber/interventions/:interventionId",
+  (req, res) => {
+    const referralNumber = req.params.referralNumber;
+    const interventionId = req.params.interventionId;
+
+    const actionPlanApproved =
+      req.session.data["approve-action-plan"] === "yes";
+
+    const referral = findReferral(
+      req.session.data.sprint6.referrals,
+      referralNumber
+    );
+
+    const intervention = referral.interventions.find(
+      (intervention) => interventionId === intervention.id
+    );
+
+    intervention.monitor.actionPlanApproved = actionPlanApproved;
+
+    const serviceUser = referral ? referral.serviceUser : {};
+
+    res.render("sprint-6/monitor/cases/intervention", {
+      referral: referral,
+      intervention: intervention,
+      serviceUser: serviceUser,
+      currentPage: intervention.name,
+    });
+  }
+);
+
 module.exports = router;

--- a/app/views/sprint-6/monitor/cases/action-plan-review.html
+++ b/app/views/sprint-6/monitor/cases/action-plan-review.html
@@ -111,6 +111,7 @@
           </ul>
 
           <div class="govuk-tabs__panel govuk-tabs__panel" id="intervention-progress">
+            <a href="/sprint-6/monitor/cases/{{referral.reference}}/interventions/{{intervention.id}}#progress" class="govuk-back-link govuk-!-margin-bottom-6">Back to Progress</a>
             <h2 class="govuk-heading-l">
               Action plan review
             </h2>

--- a/app/views/sprint-6/monitor/cases/action-plan-review.html
+++ b/app/views/sprint-6/monitor/cases/action-plan-review.html
@@ -1,0 +1,264 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Manage intervention referrals
+{% endblock %}
+
+{% block header %}
+  {{ super() }}
+  {% include "../includes/primary-navigation.html" %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
+          {{ serviceUser.name }}
+        </h1>
+        {% set currentPage = intervention.name %}
+        {% include "./side-navigation.html" %}
+
+        <div class="govuk-grid-column-one-third govuk-panel govuk-panel--sidebar--grey govuk-!-margin-top-6">
+          <ul class="govuk-list govuk-list--case-summary">
+            <li>
+              <strong>Provider</strong>
+              <br>{{ intervention.providerName }}
+            </li>
+            <li>
+              <strong>Date referred</strong>
+              <br>01/09/20
+            </li>
+            <li>
+              <strong>Assessment date</strong>
+              <br>{{ intervention.monitor.initialAssessmentDate }}
+            </li>
+            <li>
+              <strong>Date of action plan</strong>
+              <br>
+              {% if intervention.monitor.actionPlanApproved %}
+                {{ intervention.monitor.actionPlanDate }}
+              {% elif intervention.monitor.actionPlanSubmitted %}
+                Action plan not yet approved
+              {% else %}
+                Action plan not yet submitted
+              {% endif %}
+            </li>
+            <li>
+              <strong>Date started</strong>
+              <br>22/09/20
+            </li>
+            <li>
+              <strong>Target end date</strong>
+              <br>12/12/20
+            </li>
+            <li>
+              <strong>End of service review</strong>
+              <br>To be confirmed
+            </li>
+            <li>
+              <strong>RAR days allocation</strong>
+              <br>10 days
+            </li>
+            <li>
+              <strong>Appointments offered</strong>
+              <br>8
+            </li>
+            <li>
+              <strong>Appointments attended</strong>
+              <br>7
+            </li>
+            <li>
+              <strong>Acceptable absences</strong>
+              <br>1
+            </li>
+            <li>
+              <strong>Unacceptable absences</strong>
+              <br>0
+            </li>
+            <li>
+              <strong>Provider case notes</strong>
+              <br>
+              <a href="#" class="govuk-link">View notes</a>
+            </li>
+            <li>
+              <strong>Contact number</strong>
+              <br>0300 4560021
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-tabs" data-module="govuk-tabs">
+          <ul class="govuk-tabs__list">
+            <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+              <a class="govuk-tabs__tab" href="/sprint-6/monitor/cases/{{referral.reference}}/interventions/{{intervention.id}}#progress">
+                Progress
+              </a>
+            </li>
+            <li class="govuk-tabs__list-item">
+              <a class="govuk-tabs__tab" href="/sprint-6/monitor/cases/{{referral.reference}}/interventions/{{intervention.id}}#paper-trail">
+                Paper trail
+              </a>
+            </li>
+            <li class="govuk-tabs__list-item">
+              <a class="govuk-tabs__tab" href="/sprint-6/monitor/cases/{{referral.reference}}/interventions/{{intervention.id}}#statistics">
+                Statistics
+              </a>
+            </li>
+          </ul>
+
+          <div class="govuk-tabs__panel govuk-tabs__panel" id="intervention-progress">
+            <h2 class="govuk-heading-l">
+              Action plan review
+            </h2>
+            <p class="govuk-body">
+              The service provider has created an action plan for {{ serviceUser.name }}’s {{ intervention.name | lower }} intervention. Please review the following action plan and decide whether you want to approve or reject it.
+            </p>
+
+            <h2 class="govuk-heading-m">Outcomes</h2>
+
+            <h2 class="govuk-heading-s">Outcome 1</h2>
+            <p class="govuk-body">
+              Some text about outcome 1.
+            </p>
+
+            <h2 class="govuk-heading-s">Outcome 2</h2>
+            <p class="govuk-body">
+              Some text about outcome 2.
+            </p>
+
+            <h2 class="govuk-heading-m">Sessions</h2>
+
+            <table class="govuk-table">
+              <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th scope="col" class="govuk-table__header">Session title</th>
+                  <th scope="col" class="govuk-table__header">Date</th>
+                  <th scope="col" class="govuk-table__header">Facilitator</th>
+                  <th scope="col" class="govuk-table__header">Status</th>
+                  <th scope="col" class="govuk-table__header">Actions</th>
+                </tr>
+              </thead>
+
+              <tbody class="govuk-table__body">
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">Session 1</td>
+                  <td class="govuk-table__cell">07/10/20</td>
+                  <td class="govuk-table__cell">{{ intervention.assignedCaseworker }}</td>
+                  <td class="govuk-table__cell">
+                    <strong class="govuk-tag">
+                      completed
+                    </strong>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <a class="govuk-link" href="#">View</a>
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">Session 2</td>
+                  <td class="govuk-table__cell">14/10/20</td>
+                  <td class="govuk-table__cell">{{ intervention.assignedCaseworker }}</td>
+                  <td class="govuk-table__cell">
+                    <strong class="govuk-tag">
+                      completed
+                    </strong>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <a class="govuk-link" href="#">View</a>
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">Session 3</td>
+                  <td class="govuk-table__cell">21/10/20</td>
+                  <td class="govuk-table__cell">{{ intervention.assignedCaseworker }}</td>
+                  <td class="govuk-table__cell">
+                    <strong class="govuk-tag">
+                      completed
+                    </strong>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <a class="govuk-link" href="#">View</a>
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">Session 4</td>
+                  <td class="govuk-table__cell">29/10/20</td>
+                  <td class="govuk-table__cell">{{ intervention.assignedCaseworker }}</td>
+                  <td class="govuk-table__cell">
+                    <strong class="govuk-tag">
+                      completed
+                    </strong>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <a class="govuk-link" href="#">View</a>
+                  </td>
+                </tr>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">Session 5</td>
+                  <td class="govuk-table__cell">06/11/20</td>
+                  <td class="govuk-table__cell">{{ intervention.assignedCaseworker }}</td>
+                  <td class="govuk-table__cell">
+                    <strong class="govuk-tag">
+                      completed
+                    </strong>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <a class="govuk-link" href="#">View</a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+
+            <div class="govuk-form-group">
+              <form action="/sprint-6/monitor/cases/{{referral.reference}}/interventions/{{intervention.id}}" method="post" class="form">
+                <fieldset class="govuk-fieldset">
+                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                    <h2 class="govuk-fieldset__heading">
+                      Do you want to approve this action plan?
+                    </h2>
+                  </legend>
+                  <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+                    <div class="govuk-radios__item">
+                      <input class="govuk-radios__input" id="approve-action-plan" name="approve-action-plan" value="yes" type="radio" data-aria-controls="conditional-approve-action-plan">
+                      <label class="govuk-label govuk-radios__label" for="approve-action-plan">
+                        Yes, approved.
+                      </label>
+                    </div>
+                    <div class="govuk-radios__item">
+                      <input class="govuk-radios__input" id="reject-action-plan" name="approve-action-plan" value="no" type="radio" data-aria-controls="conditional-reject-action-plan">
+                      <label class="govuk-label govuk-radios__label" for="reject-action-plan">
+                        No, I would like to reject it and make some comments.
+                      </label>
+                    </div>
+                    <div class="conditional-section govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-reject-action-plan">
+                      <div class="govuk-form-group">
+                        <label class="govuk-label" for="reasons-for-rejection">
+                          Please enter the reasons why you reject it:
+                        </label>
+                        <textarea class="govuk-textarea" id="reasons-for-rejection" rows="5" name="reasons-for-rejection"></textarea>
+                      </div>
+
+                      <button class="govuk-button" data-module="govuk-button">
+                        Reject
+                      </button>
+                    </div>
+
+                    <div class="conditional-section govuk-radios__conditional govuk-radios__conditional--hidden govuk-!-margin-top-6" id="conditional-approve-action-plan">
+                      <button class="govuk-button" data-module="govuk-button">
+                        Approve
+                      </button>
+                    </div>
+                  </div>
+                </fieldset>
+
+              </form>
+
+            </div>
+
+          </div>
+        </div>
+      </div>
+    {% endblock %}

--- a/app/views/sprint-6/monitor/cases/intervention.html
+++ b/app/views/sprint-6/monitor/cases/intervention.html
@@ -195,7 +195,7 @@
                       {% endif %}
                     </td>
                     <td class="govuk-table__cell">
-                      <a href="#" class="govuk-link">View</td>
+                      <a href="{{intervention.id}}/action-plan" class="govuk-link">View</td>
                     </tr>
                   </tbody>
               </table>


### PR DESCRIPTION
## Changes in this PR

This allows users to approve or reject an action plan for a specific intervention, updating the action plan specified. It currently doesn't do much with the data, apart from displaying the action plan as "approved" on the intervention page. There's currently no behaviour for when it's rejected (it will still be marked as "awaiting approval").

## Screenshots 
![image](https://user-images.githubusercontent.com/19826940/96114979-3767a500-0ede-11eb-94c8-c62607f4df17.png)
