### PR TITLE
Fix Make a Referral typo

### DIFF
--- a/app/views/sprint-2/book-and-manage/make-a-referral/accommodation-service/complexity-level.html
+++ b/app/views/sprint-2/book-and-manage/make-a-referral/accommodation-service/complexity-level.html
@@ -36,7 +36,7 @@
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="low" name="accommodation-complexity" type="radio" value="Low complexity" {{ checked("accommodation-complexity", "Low complexity") }}>
               <label class="govuk-label govuk-radios__label" for="accommodation-complexity">
-                Low complexity<br>Service User has some capacity and means to secure and/or maintain suitable accommodation but quires some support and guidance to do so.
+                Low complexity<br>Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.
               </label>
             </div>
             <div class="govuk-radios__item">

--- a/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/complexity-level.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/complexity-level.html
@@ -36,7 +36,7 @@
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="low" name="accommodation-complexity" type="radio" value="Low complexity" {{ checked("accommodation-complexity", "Low complexity") }}>
               <label class="govuk-label govuk-radios__label" for="accommodation-complexity">
-                Low complexity<br>Service User has some capacity and means to secure and/or maintain suitable accommodation but quires some support and guidance to do so.
+                Low complexity<br>Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.
               </label>
             </div>
             <div class="govuk-radios__item">


### PR DESCRIPTION
I've fixed this in 2 places (both sprints) because it's a typo rather
than a functionality change and I don't think we currently link to the
Make a Referral sprint 6 page in the dashboard anywhere.