### PR TITLE
Update no-show journey and display probation practitioner judgement on absences

### DIFF
--- a/app/routes/sprint-6/caseworkerManageRoutes.js
+++ b/app/routes/sprint-6/caseworkerManageRoutes.js
@@ -258,6 +258,8 @@ router.get("/referrals/:referralIndex/interventions/:interventionIndex", (req, r
 	}
     }
 
+    viewModel.noShowSessionIndex = intervention.sessions.findIndex(session => (session.assessment != null && session.assessment.attended === "no" && session.absenceJudgement == null));
+
     res.render("sprint-6/book-and-manage/manage-a-referral/caseworker/intervention", { referral, intervention, referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex, allSessionsAssessed, canChangeActionPlan, cssClassForInitialAssessmentStatus, cssClassForSessionStatus, cssClassForInterventionSessionsStatus, cssClassForActionPlanStatus, cssClassForEndOfServiceReportStatus, initialAssessmentScheduled, viewModel });
 });
 
@@ -374,12 +376,22 @@ router.post("/referrals/:referralIndex/interventions/:interventionIndex/sessions
     res.redirect(`/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
 });
 
+router.get("/referrals/:referralIndex/interventions/:interventionIndex/sessions/:sessionIndex/fast-forward/probation-practitioner-judgement/:judgement", (req, res) => {
+    const intervention = findIntervention(req);
+    const sessionIndex = parseInt(req.params.sessionIndex);
+    const session = intervention.sessions[sessionIndex];
+
+    session.absenceJudgement = req.params.judgement;
+
+    res.redirect(`/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
+});
+
 router.get("/referrals/:referralIndex/interventions/:interventionIndex/fast-forward/sessions-completed", (req, res) => {
     const intervention = findIntervention(req);
 
     for (session of intervention.sessions) {
 	if (session.assessment == null) {
-	    session.assessment = {};
+	    session.assessment = { attended: "yes" };
 	}
     }
 

--- a/app/routes/sprint-6/caseworkerManageRoutes.js
+++ b/app/routes/sprint-6/caseworkerManageRoutes.js
@@ -324,16 +324,25 @@ router.get("/referrals/:referralIndex/interventions/:interventionIndex/sessions/
     res.redirect(`/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/sessions/${req.params.sessionIndex}/assessment/attended`);
 });
 
-for (const page of ["attended", "details"]) {
-    router.get(`/referrals/:referralIndex/interventions/:interventionIndex/sessions/:sessionIndex/assessment/${page}`, (req, res) => {
-	const intervention = findIntervention(req);
-	const referral = findReferral(req);
+router.get(`/referrals/:referralIndex/interventions/:interventionIndex/sessions/:sessionIndex/assessment/attended`, (req, res) => {
+    const intervention = findIntervention(req);
+    const referral = findReferral(req);
 
-	const sessionIndex = parseInt(req.params.sessionIndex);
+    const sessionIndex = parseInt(req.params.sessionIndex);
 
-	res.render(`sprint-6/book-and-manage/manage-a-referral/caseworker/assessment-${page}`, { referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex, intervention, sessionIndex, referral });
-    });
-}
+    res.render(`sprint-6/book-and-manage/manage-a-referral/caseworker/assessment-attended`, { referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex, intervention, sessionIndex, referral });
+});
+
+router.get(`/referrals/:referralIndex/interventions/:interventionIndex/sessions/:sessionIndex/assessment/details`, (req, res) => {
+    const intervention = findIntervention(req);
+    const referral = findReferral(req);
+
+    const sessionIndex = parseInt(req.params.sessionIndex);
+    const session = intervention.sessions[sessionIndex];
+    const attended = session.wipAssessment.attended !== "no";
+
+    res.render(`sprint-6/book-and-manage/manage-a-referral/caseworker/assessment-details`, { referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex, intervention, sessionIndex, referral, attended });
+});
 
 function updateWipAssessmentFromRequest(req) {
     const intervention = findIntervention(req);

--- a/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/assessment-attended.html
+++ b/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/assessment-attended.html
@@ -1,0 +1,49 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Session {{sessionIndex + 1}}: assessment
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Session {{sessionIndex + 1}}: assessment</h1>
+
+      <form method="post">
+
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h2 class="govuk-fieldset__heading">Did {{ referral.serviceUser.firstName }} attend session {{sessionIndex + 1}}?</h2>
+            </legend>
+
+            <div class="govuk-radios">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="attended-on-time" name="attended" type="radio" value="on-time">
+                <label class="govuk-label govuk-radios__label" for="attended-on-time">Yes, on time</label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="attended-late" name="attended" type="radio" value="late">
+                <label class="govuk-label govuk-radios__label" for="attended-late">Late arrival</label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="attended-no" name="attended" type="radio" value="no">
+                <label class="govuk-label govuk-radios__label" for="attended-no">No</label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="attendance-comment">
+            Add additional information about attendance (optional)
+          </label>
+
+          <textarea class="govuk-textarea" id="attendance-comment" name="attendance-comment"></textarea>
+        </div>
+
+        <input type="submit" class="govuk-button" data-module="govuk-button" value="Continue">
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/assessment-details.html
+++ b/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/assessment-details.html
@@ -9,38 +9,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Session {{sessionIndex + 1}}: assessment</h1>
 
-      <form method="post" action="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions/{{sessionIndex}}/assessment">
-
-        <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-              <h2 class="govuk-fieldset__heading">Did {{ referral.serviceUser.firstName }} attend session {{sessionIndex + 1}}?</h2>
-            </legend>
-
-            <div class="govuk-radios">
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="attended-on-time" name="attended" type="radio" value="on-time">
-                <label class="govuk-label govuk-radios__label" for="attended-on-time">Yes, on time</label>
-              </div>
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="attended-late" name="attended" type="radio" value="late">
-                <label class="govuk-label govuk-radios__label" for="attended-late">Late arrival</label>
-              </div>
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="attended-no" name="attended" type="radio" value="no">
-                <label class="govuk-label govuk-radios__label" for="attended-no">No</label>
-              </div>
-            </div>
-          </fieldset>
-        </div>
-
-        <div class="govuk-form-group">
-          <label class="govuk-label" for="attendance-comment">
-            Add additional information about attendance (optional)
-          </label>
-
-          <textarea class="govuk-textarea" id="attendance-comment" name="attendance-comment"></textarea>
-        </div>
+      <form method="post">
 
         {% for aspect in ["behaviour", "attitude", "relationship management skills"] %}
           <div class="govuk-form-group">

--- a/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/assessment-details.html
+++ b/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/assessment-details.html
@@ -11,78 +11,82 @@
 
       <form method="post">
 
-        {% for aspect in ["behaviour", "attitude", "relationship management skills"] %}
+        {% if attended %}
+
+          {% for aspect in ["behaviour", "attitude", "relationship management skills"] %}
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                  <h2 class="govuk-fieldset__heading">Assess {{ referral.serviceUser.firstName }}’s {{ aspect }}</h2>
+                </legend>
+
+                <div class="govuk-radios">
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="{{aspect}}-1" name="{{aspect}}" type="radio" value="1">
+                    <label class="govuk-label govuk-radios__label" for="{{aspect}}-1">1 - Poor</label>
+                  </div>
+
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="{{aspect}}-2" name="{{aspect}}" type="radio" value="2">
+                    <label class="govuk-label govuk-radios__label" for="{{aspect}}-2">2 - Fair</label>
+                  </div>
+
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="{{aspect}}-3" name="{{aspect}}" type="radio" value="3">
+                    <label class="govuk-label govuk-radios__label" for="{{aspect}}-3">3 - Good</label>
+                  </div>
+
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="{{aspect}}-4" name="{{aspect}}" type="radio" value="4">
+                    <label class="govuk-label govuk-radios__label" for="{{aspect}}-4">4 - Very good</label>
+                  </div>
+
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="{{aspect}}-5" name="{{aspect}}" type="radio" value="5">
+                    <label class="govuk-label govuk-radios__label" for="{{aspect}}-5">5 - Excellent</label>
+                  </div>
+                </div>
+              </fieldset>
+
+            </div>
+
+            <div class="govuk-form-group">
+              <label class="govuk-label" for="{{aspect}}-justification">
+                Why did you give {{ referral.serviceUser.firstName }} that rating?
+              </label>
+
+              <textarea class="govuk-textarea" id="{{aspect}}-justification" name="{{aspect}}-justification"></textarea>
+            </div>
+          {% endfor %}
+
           <div class="govuk-form-group">
             <fieldset class="govuk-fieldset">
               <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                <h2 class="govuk-fieldset__heading">Assess {{ referral.serviceUser.firstName }}’s {{ aspect }}</h2>
+                <h2 class="govuk-fieldset__heading">Are there any additional safeguarding concerns following this assessment?</h2>
               </legend>
 
               <div class="govuk-radios">
                 <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="{{aspect}}-1" name="{{aspect}}" type="radio" value="1">
-                  <label class="govuk-label govuk-radios__label" for="{{aspect}}-1">1 - Poor</label>
+                  <input class="govuk-radios__input" id="safeguarding-issues-yes" name="safeguarding-issues" type="radio" value="yes">
+                  <label class="govuk-label govuk-radios__label" for="safeguarding-issues-yes">Yes</label>
                 </div>
-
                 <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="{{aspect}}-2" name="{{aspect}}" type="radio" value="2">
-                  <label class="govuk-label govuk-radios__label" for="{{aspect}}-2">2 - Fair</label>
-                </div>
-
-                <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="{{aspect}}-3" name="{{aspect}}" type="radio" value="3">
-                  <label class="govuk-label govuk-radios__label" for="{{aspect}}-3">3 - Good</label>
-                </div>
-
-                <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="{{aspect}}-4" name="{{aspect}}" type="radio" value="4">
-                  <label class="govuk-label govuk-radios__label" for="{{aspect}}-4">4 - Very good</label>
-                </div>
-
-                <div class="govuk-radios__item">
-                  <input class="govuk-radios__input" id="{{aspect}}-5" name="{{aspect}}" type="radio" value="5">
-                  <label class="govuk-label govuk-radios__label" for="{{aspect}}-5">5 - Excellent</label>
+                  <input class="govuk-radios__input" id="safeguarding-issues-no" name="safeguarding-issues" type="radio" value="no">
+                  <label class="govuk-label govuk-radios__label" for="safeguarding-issues-no">No</label>
                 </div>
               </div>
             </fieldset>
-
           </div>
 
           <div class="govuk-form-group">
-            <label class="govuk-label" for="{{aspect}}-justification">
-              Why did you give {{ referral.serviceUser.firstName }} that rating?
+            <label class="govuk-label" for="safeguarding-issues-content">
+              The probation practitioner will receive an alert if there have been any additional concerns
             </label>
 
-            <textarea class="govuk-textarea" id="{{aspect}}-justification" name="{{aspect}}-justification"></textarea>
+            <textarea class="govuk-textarea" id="safeguarding-issues-content" name="safeguarding-issues-content"></textarea>
           </div>
-        {% endfor %}
 
-        <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-              <h2 class="govuk-fieldset__heading">Are there any additional safeguarding concerns following this assessment?</h2>
-            </legend>
-
-            <div class="govuk-radios">
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="safeguarding-issues-yes" name="safeguarding-issues" type="radio" value="yes">
-                <label class="govuk-label govuk-radios__label" for="safeguarding-issues-yes">Yes</label>
-              </div>
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="safeguarding-issues-no" name="safeguarding-issues" type="radio" value="no">
-                <label class="govuk-label govuk-radios__label" for="safeguarding-issues-no">No</label>
-              </div>
-            </div>
-          </fieldset>
-        </div>
-
-        <div class="govuk-form-group">
-          <label class="govuk-label" for="safeguarding-issues-content">
-            The probation practitioner will receive an alert if there have been any additional concerns
-          </label>
-
-          <textarea class="govuk-textarea" id="safeguarding-issues-content" name="safeguarding-issues-content"></textarea>
-        </div>
+        {% endif %}
 
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset">

--- a/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/includes/intervention/progress.html
+++ b/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/includes/intervention/progress.html
@@ -5,6 +5,7 @@
       <th class="govuk-table__header" scope="col">Date</th>
       <th class="govuk-table__header" scope="col">Time</th>
       <th class="govuk-table__header" scope="col">Status</th>
+      <th class="govuk-table__header" scope="col">Attendance</th>
       <th class="govuk-table__header" scope="col">Action</th>
     </tr>
   </thead>
@@ -17,6 +18,21 @@
       <td class="govuk-table__cell ">
         {% if session.status != "not started" %}
           <strong class="{{ cssClassForSessionStatus(session.status) }}">{{ session.status }}</strong>
+        {% endif %}
+      </td>
+      <td class="govuk-table__cell ">
+        {% if session.assessment != null %}
+          {% if session.assessment.attended == "no" %}
+            {% if session.absenceJudgement == "acceptable" %}
+              No, but acceptable
+            {% elif session.absenceJudgement == "unacceptable" %}
+              No, and unacceptable
+            {% else %}
+              No, awaiting judgement
+            {% endif %}
+          {% else %}
+            Yes
+          {% endif %}
         {% endif %}
       </td>
       <td class="govuk-table__cell">

--- a/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/intervention.html
+++ b/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/intervention.html
@@ -71,6 +71,16 @@
 	<a class="govuk-link govuk-link--app-fast-forward" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/action-plan-approved">User research example: fast-forward to action plan approved</a>
 	</p>
       {% endif %}
+
+      {% if viewModel.noShowSessionIndex !== -1 %}
+	<p class="govuk-body">
+	<a class="govuk-link govuk-link--app-fast-forward" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions/{{viewModel.noShowSessionIndex}}/fast-forward/probation-practitioner-judgement/acceptable">User research example: fast-forward session {{ viewModel.noShowSessionIndex + 1 }} to acceptable absence</a>
+	</p>
+
+	<p class="govuk-body">
+	<a class="govuk-link govuk-link--app-fast-forward" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions/{{viewModel.noShowSessionIndex}}/fast-forward/probation-practitioner-judgement/unacceptable">User research example: fast-forward session {{ viewModel.noShowSessionIndex + 1 }} to unacceptable absence</a>
+	</p>
+      {% endif %}
     </div>
 
   </div>

--- a/server.js
+++ b/server.js
@@ -326,7 +326,7 @@ app.use(function (req, res, next) {
 
 // Display error
 app.use(function (err, req, res, next) {
-  console.error(err.message)
+  console.error(err.message, err.stack)
   res.status(err.status || 500)
   res.send(err.message)
 })


### PR DESCRIPTION
# What's new

This updates the no-show journey to match the latest designs, in which:

- the attendance question is split out separately
- the caseworker is able to see the probation practitioner's judgement on whether an absence was acceptable or not

We provide fast-forward links to simulate the probation practitioner’s judgement being received.

I also snuck in a little technical change, to print out a stack trace on request error. It was handy when debugging this.

# Screenshot

## Post-session assessment: attendance question

![image](https://user-images.githubusercontent.com/53756884/96552895-508c9f00-12ac-11eb-8c0c-bf45041bead8.png)

## Post-session assessment: didn’t attend

![image](https://user-images.githubusercontent.com/53756884/96552940-5bdfca80-12ac-11eb-8f7f-7fdc2153a9c7.png)

## Absence awaiting judgement

This also shows the fast-forward links.

![image](https://user-images.githubusercontent.com/53756884/96552736-16bb9880-12ac-11eb-8154-6d2594d56b79.png)

## All sessions completed and absence judged

![Screenshot_2020-10-20 Manage intervention referrals](https://user-images.githubusercontent.com/53756884/96552575-d5c38400-12ab-11eb-8593-39684fd6d79f.png)
