### PR TITLE
Sprint 6: Make back links go to previous page

### DIFF
--- a/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/completion-date.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/completion-date.html
@@ -6,19 +6,11 @@
 
 {% block beforeContent %}
 
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
+ {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: "complexity-level"
+    href: "javascript: window.history.go(-1)"
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/complexity-level.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/complexity-level.html
@@ -5,20 +5,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "desired-outcomes"
+    href: "javascript: window.history.go(-1)"
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/desired-outcomes.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/desired-outcomes.html
@@ -5,20 +5,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "select-sentence"
+    href: "javascript: window.history.go(-1)"
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/further-information.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/further-information.html
@@ -5,20 +5,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "rar-days"
+    href: "javascript: window.history.go(-1)"
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/rar-days.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/rar-days.html
@@ -5,20 +5,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "completion-date"
+    href: "javascript: window.history.go(-1)"
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/select-sentence.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/select-sentence.html
@@ -5,20 +5,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "../referral-task-list"
+    href: "javascript: window.history.go(-1)"
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/check-answers.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/check-answers.html
@@ -5,20 +5,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "referral-task-list"
+    href: "javascript: window.history.go(-1)"
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/needs-and-requirements.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/needs-and-requirements.html
@@ -5,18 +5,9 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "service-user-details"
+    href: "javascript: window.history.go(-1)"
   }) }}
 {% endblock %}
 

--- a/app/views/sprint-6/book-and-manage/make-a-referral/responsible-officer-information.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/responsible-officer-information.html
@@ -5,20 +5,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "referral-task-list"
+    href: "javascript: window.history.go(-1)"
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/risk-information.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/risk-information.html
@@ -5,18 +5,9 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "service-user-details"
+    href: "javascript: window.history.go(-1)"
   }) }}
 {% endblock %}
 

--- a/app/views/sprint-6/book-and-manage/make-a-referral/service-user-details.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/service-user-details.html
@@ -9,6 +9,13 @@
   {% include "../../includes/primary-navigation.html" %}
 {% endblock %}
 
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "javascript: window.history.go(-1)"
+  }) }}
+{% endblock %}
+
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/sprint-6/book-and-manage/make-a-referral/service-user-id.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/service-user-id.html
@@ -6,13 +6,14 @@
 
 {% block header %}
   {{ super() }}
+  {% set currentPage = "make-a-referral" %}
   {% include "../../includes/primary-navigation.html" %}
 {% endblock %}
 
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: "referral-task-list"
+    href: "javascript: window.history.go(-1)"
   }) }}
 {% endblock %}
 

--- a/app/views/sprint-6/book-and-manage/make-a-referral/service-user-personal-information.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/service-user-personal-information.html
@@ -16,7 +16,7 @@
 
   {{ govukBackLink({
     text: "Back",
-    href: "service-user-id"
+    href: "javascript: window.history.go(-1)"
   }) }}
 
 {% endblock %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/completion-date.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/completion-date.html
@@ -5,20 +5,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "complexity-level"
+    href: "javascript: window.history.go(-1)"
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/complexity-level.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/complexity-level.html
@@ -5,20 +5,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "desired-outcomes"
+    href: "javascript: window.history.go(-1)"
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/desired-outcomes.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/desired-outcomes.html
@@ -5,20 +5,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "select-sentence"
+    href: "javascript: window.history.go(-1)"
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/further-information.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/further-information.html
@@ -5,20 +5,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "rar-days"
+    href: "javascript: window.history.go(-1)"
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/rar-days.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/rar-days.html
@@ -5,20 +5,10 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "completion-date"
+    href: "javascript: window.history.go(-1)"
   }) }}
-
 {% endblock %}
 
 {% block content %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/select-sentence.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/select-sentence.html
@@ -5,18 +5,9 @@
 {% endblock %}
 
 {% block beforeContent %}
-
-  {% from 'govuk/components/phase-banner/macro.njk' import govukPhaseBanner %}
-  {{ govukPhaseBanner({
-    tag: {
-      text: "prototype"
-    },
-    html: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-  }) }}
-
   {{ govukBackLink({
     text: "Back",
-    href: "../referral-task-list"
+    href: "javascript: window.history.go(-1)"
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
rather than hardcoding them, we're using javascript. It's not ideal, but
it's a quick way of pulling these pages all together for now.

Also removes some phase banners in headers as they don't blend well with
the primary navigation