### PR TITLE
Make fast-forward links a bit more subtle

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -121,6 +121,14 @@ $govuk-assets-path: '/govuk/assets/';
   }
 }
 
+.govuk-link--app-fast-forward-subtler {
+  color: govuk-colour("dark-grey") !important;
+
+  &:visited {
+    color: govuk-colour("dark-grey") !important;
+  }
+}
+
 // TODO This didn’t work with the class there only once (just uses the 960px of
 // the Design System’s govuk-width-container rule) - understand what was
 // happening specificity/ordering-wise

--- a/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/intervention.html
+++ b/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/intervention.html
@@ -62,23 +62,23 @@
       </p>
       {% if viewModel.populateInterventionSessionsContent and not allSessionsAssessed %}
 	<p>
-	<a class="govuk-link govuk-link--app-fast-forward" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/sessions-completed">User research example: fast-forward to sessions completed</a>
+	<a class="govuk-link govuk-link--app-fast-forward-subtler" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/sessions-completed">User research example: fast-forward to sessions completed</a>
 	</p>
       {% endif %}
 
       {% if viewModel.populateActionPlanContent and intervention.actionPlanStatus === "pending approval" %}
 	<p class="govuk-body">
-	<a class="govuk-link govuk-link--app-fast-forward" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/action-plan-approved">User research example: fast-forward to action plan approved</a>
+	<a class="govuk-link govuk-link--app-fast-forward-subtler" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/action-plan-approved">User research example: fast-forward to action plan approved</a>
 	</p>
       {% endif %}
 
       {% if viewModel.noShowSessionIndex !== -1 %}
 	<p class="govuk-body">
-	<a class="govuk-link govuk-link--app-fast-forward" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions/{{viewModel.noShowSessionIndex}}/fast-forward/probation-practitioner-judgement/acceptable">User research example: fast-forward session {{ viewModel.noShowSessionIndex + 1 }} to acceptable absence</a>
+	<a class="govuk-link govuk-link--app-fast-forward-subtler" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions/{{viewModel.noShowSessionIndex}}/fast-forward/probation-practitioner-judgement/acceptable">User research example: fast-forward session {{ viewModel.noShowSessionIndex + 1 }} to acceptable absence</a>
 	</p>
 
 	<p class="govuk-body">
-	<a class="govuk-link govuk-link--app-fast-forward" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions/{{viewModel.noShowSessionIndex}}/fast-forward/probation-practitioner-judgement/unacceptable">User research example: fast-forward session {{ viewModel.noShowSessionIndex + 1 }} to unacceptable absence</a>
+	<a class="govuk-link govuk-link--app-fast-forward-subtler" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions/{{viewModel.noShowSessionIndex}}/fast-forward/probation-practitioner-judgement/unacceptable">User research example: fast-forward session {{ viewModel.noShowSessionIndex + 1 }} to unacceptable absence</a>
 	</p>
       {% endif %}
     </div>


### PR DESCRIPTION
# What's new

We think that in their current redness the fast-forward links might be quite distracting to research participants, so change them to a disabled-looking grey.

# Screenshot

![image](https://user-images.githubusercontent.com/53756884/96591961-c3fbd400-12df-11eb-8d9e-e19bfb3922d6.png)
