### PR TITLE
Change absence judgement fast forward link behaviour

### DIFF
--- a/app/routes/sprint-6/caseworkerManageRoutes.js
+++ b/app/routes/sprint-6/caseworkerManageRoutes.js
@@ -280,9 +280,7 @@ router.post("/referrals/:referralIndex/interventions/:interventionIndex/goals", 
     res.redirect(`/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/action-plan#goals`);
 });
 
-router.post("/referrals/:referralIndex/interventions/:interventionIndex/sessions", (req, res) => {
-    const intervention = findIntervention(req);
-
+function addSessionToIntervention(intervention) {
     // We don’t yet have a proper “add session” page, so start tomorrow and
     // increment by a week each time
     var date;
@@ -294,6 +292,12 @@ router.post("/referrals/:referralIndex/interventions/:interventionIndex/sessions
 
     const session = { title: `Session ${intervention.sessions.length + 1}`, date: date, startTime: "17:00", endTime: "18:00" }
     intervention.sessions.push(session);
+}
+
+router.post("/referrals/:referralIndex/interventions/:interventionIndex/sessions", (req, res) => {
+    const intervention = findIntervention(req);
+
+    addSessionToIntervention(intervention);
 
     res.redirect(`/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/action-plan#sessions`);
 });
@@ -375,12 +379,26 @@ router.post("/referrals/:referralIndex/interventions/:interventionIndex/sessions
     res.redirect(`/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
 });
 
-router.get("/referrals/:referralIndex/interventions/:interventionIndex/sessions/:sessionIndex/fast-forward/probation-practitioner-judgement/:judgement", (req, res) => {
+router.get("/referrals/:referralIndex/interventions/:interventionIndex/sessions/:sessionIndex/fast-forward/probation-practitioner-judgement", (req, res) => {
     const intervention = findIntervention(req);
     const sessionIndex = parseInt(req.params.sessionIndex);
     const session = intervention.sessions[sessionIndex];
 
-    session.absenceJudgement = req.params.judgement;
+    // We want to demonstrate what an acceptable and an unacceptable absence
+    // look like.
+
+    // Fake a judgement as an acceptable absence.
+    session.absenceJudgement = "acceptable";
+
+    // If there are no more sessions after this one, then add another one.
+    if (sessionIndex == intervention.sessions.length - 1) {
+	addSessionToIntervention(intervention);
+    }
+
+    const nextSession = intervention.sessions[sessionIndex + 1];
+    // Fake an assessment and a judgement as an unacceptable absence.
+    nextSession.assessment = { attended: "no" };
+    nextSession.absenceJudgement = "unacceptable";
 
     res.redirect(`/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
 });

--- a/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/intervention.html
+++ b/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/intervention.html
@@ -60,11 +60,6 @@
       <p>
       <a class="govuk-link" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/communication-archive">View communication history</a>
       </p>
-      {% if viewModel.populateInterventionSessionsContent and not allSessionsAssessed %}
-	<p>
-	<a class="govuk-link govuk-link--app-fast-forward-subtler" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/sessions-completed">User research example: fast-forward to sessions completed</a>
-	</p>
-      {% endif %}
 
       {% if viewModel.populateActionPlanContent and intervention.actionPlanStatus === "pending approval" %}
 	<p class="govuk-body">
@@ -79,6 +74,10 @@
 
 	<p class="govuk-body">
 	<a class="govuk-link govuk-link--app-fast-forward-subtler" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions/{{viewModel.noShowSessionIndex}}/fast-forward/probation-practitioner-judgement/unacceptable">User research example: fast-forward session {{ viewModel.noShowSessionIndex + 1 }} to unacceptable absence</a>
+	</p>
+      {% elif viewModel.populateInterventionSessionsContent and not allSessionsAssessed %}
+	<p>
+	<a class="govuk-link govuk-link--app-fast-forward-subtler" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/sessions-completed">User research example: fast-forward to sessions completed</a>
 	</p>
       {% endif %}
     </div>

--- a/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/intervention.html
+++ b/app/views/sprint-6/book-and-manage/manage-a-referral/caseworker/intervention.html
@@ -60,7 +60,6 @@
       <p>
       <a class="govuk-link" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/communication-archive">View communication history</a>
       </p>
-
       {% if viewModel.populateActionPlanContent and intervention.actionPlanStatus === "pending approval" %}
 	<p class="govuk-body">
 	<a class="govuk-link govuk-link--app-fast-forward-subtler" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/action-plan-approved">User research example: fast-forward to action plan approved</a>
@@ -69,11 +68,7 @@
 
       {% if viewModel.noShowSessionIndex !== -1 %}
 	<p class="govuk-body">
-	<a class="govuk-link govuk-link--app-fast-forward-subtler" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions/{{viewModel.noShowSessionIndex}}/fast-forward/probation-practitioner-judgement/acceptable">User research example: fast-forward session {{ viewModel.noShowSessionIndex + 1 }} to acceptable absence</a>
-	</p>
-
-	<p class="govuk-body">
-	<a class="govuk-link govuk-link--app-fast-forward-subtler" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions/{{viewModel.noShowSessionIndex}}/fast-forward/probation-practitioner-judgement/unacceptable">User research example: fast-forward session {{ viewModel.noShowSessionIndex + 1 }} to unacceptable absence</a>
+	<a class="govuk-link govuk-link--app-fast-forward-subtler" href="/sprint-6/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions/{{viewModel.noShowSessionIndex}}/fast-forward/probation-practitioner-judgement">User research example: fast-forward to PP judgement</a>
 	</p>
       {% elif viewModel.populateInterventionSessionsContent and not allSessionsAssessed %}
 	<p>


### PR DESCRIPTION
# What's new

- we now only have a single fast-forward link instead of two for simulating a PP's judgement on an absence
- we only display one fast-forward link at a time