### PR TITLE
Don't show interventions in Refer task list until they're chosen in Find

### DIFF
--- a/app/views/sprint-6/book-and-manage/make-a-referral/referral-task-list.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/referral-task-list.html
@@ -178,169 +178,173 @@
           </ul>
         </li>
 
-        <li>
-          {% if data["accommodation-more-info-completed"] %}
-            <strong class="govuk-tag govuk-tag app-task-list__tag">
-              completed
-            </strong>
-          {% elseif data["accommodation-sentence"] %}
-            <strong class="govuk-tag govuk-tag app-task-list__tag">
-              in progress
-            </strong>
-          {% elseif data["needs-and-requirements-completed"] %}
-            <strong class="govuk-tag govuk-tag--grey app-task-list__tag">
-              not started
-            </strong>
-          {% else %}
-            <strong class="govuk-tag govuk-tag--grey app-task-list__tag">
-              cannot start yet
-            </strong>
-          {% endif %}
-          <h2 class="moj-task-list__section">
-            <span class="moj-task-list__section-number">5.
-            </span>
-            Accommodation referral
-          </h2>
-          <ul class="moj-task-list__items">
-            <li class="moj-task-list__item">
-              {% if data["needs-and-requirements-completed"] %}
-                <a class="moj-task-list__task-name" href="accommodation-service/select-sentence">Select relevant sentence</a>
-              {% else %}
-                <span class="app-task-list__task-name">
-                  Select relevant sentence
-                </span>
-              {% endif %}
-            </li>
-            <li class="moj-task-list__item">
-              {% if data["accommodation-sentence"] %}
-                <a class="moj-task-list__task-name" href="accommodation-service/desired-outcomes">Select desired outcomes</a>
-              {% else %}
-                <span class="app-task-list__task-name">
-                  Select desired outcomes
-                </span>
-              {% endif %}
-            </li>
-            <li class="moj-task-list__item">
-              {% if data["accommodation-desired-outcomes"] %}
-                <a class="moj-task-list__task-name" href="accommodation-service/complexity-level">Select required complexity level</a>
-              {% else %}
-                <span class="app-task-list__task-name">
-                  Select required complexity level
-                </span>
-              {% endif %}
-            </li>
-            <li class="moj-task-list__item">
-              {% if data["accommodation-desired-outcomes"] %}
-                <a class="moj-task-list__task-name" href="accommodation-service/completion-date">What date does the accommodation service need to be completed by?</a>
-              {% else %}
-                <span class="app-task-list__task-name">
-                  What date does the accommodation service need to be completed by?
-                </span>
-              {% endif %}
-            </li>
-            <li class="moj-task-list__item">
-              {% if data["accommodation-date-year"] %}
-                <a class="moj-task-list__task-name" href="accommodation-service/rar-days">Enter RAR days used</a>
-              {% else %}
-                <span class="app-task-list__task-name">
-                  Enter RAR days used
-                </span>
-              {% endif %}
-            </li>
-            <li class="moj-task-list__item">
-              {% if data["accommodation-using-rar-days"] %}
-                <a class="moj-task-list__task-name" href="accommodation-service/further-information">Further information for service provider</a>
-              {% else %}
-                <span class="app-task-list__task-name">
-                  Further information for service provider
-                </span>
-              {% endif %}
-            </li>
-          </ul>
-        </li>
+        {% if data["found-interventions"] %}
+          <li>
+            {% if data["accommodation-more-info-completed"] %}
+              <strong class="govuk-tag govuk-tag app-task-list__tag">
+                completed
+              </strong>
+            {% elseif data["accommodation-sentence"] %}
+              <strong class="govuk-tag govuk-tag app-task-list__tag">
+                in progress
+              </strong>
+            {% elseif data["needs-and-requirements-completed"] %}
+              <strong class="govuk-tag govuk-tag--grey app-task-list__tag">
+                not started
+              </strong>
+            {% else %}
+              <strong class="govuk-tag govuk-tag--grey app-task-list__tag">
+                cannot start yet
+              </strong>
+            {% endif %}
+            <h2 class="moj-task-list__section">
+              <span class="moj-task-list__section-number">5.
+              </span>
+              Accommodation referral
+            </h2>
+            <ul class="moj-task-list__items">
+              <li class="moj-task-list__item">
+                {% if data["needs-and-requirements-completed"] %}
+                  <a class="moj-task-list__task-name" href="accommodation-service/select-sentence">Select relevant sentence</a>
+                {% else %}
+                  <span class="app-task-list__task-name">
+                    Select relevant sentence
+                  </span>
+                {% endif %}
+              </li>
+              <li class="moj-task-list__item">
+                {% if data["accommodation-sentence"] %}
+                  <a class="moj-task-list__task-name" href="accommodation-service/desired-outcomes">Select desired outcomes</a>
+                {% else %}
+                  <span class="app-task-list__task-name">
+                    Select desired outcomes
+                  </span>
+                {% endif %}
+              </li>
+              <li class="moj-task-list__item">
+                {% if data["accommodation-desired-outcomes"] %}
+                  <a class="moj-task-list__task-name" href="accommodation-service/complexity-level">Select required complexity level</a>
+                {% else %}
+                  <span class="app-task-list__task-name">
+                    Select required complexity level
+                  </span>
+                {% endif %}
+              </li>
+              <li class="moj-task-list__item">
+                {% if data["accommodation-desired-outcomes"] %}
+                  <a class="moj-task-list__task-name" href="accommodation-service/completion-date">What date does the accommodation service need to be completed by?</a>
+                {% else %}
+                  <span class="app-task-list__task-name">
+                    What date does the accommodation service need to be completed by?
+                  </span>
+                {% endif %}
+              </li>
+              <li class="moj-task-list__item">
+                {% if data["accommodation-date-year"] %}
+                  <a class="moj-task-list__task-name" href="accommodation-service/rar-days">Enter RAR days used</a>
+                {% else %}
+                  <span class="app-task-list__task-name">
+                    Enter RAR days used
+                  </span>
+                {% endif %}
+              </li>
+              <li class="moj-task-list__item">
+                {% if data["accommodation-using-rar-days"] %}
+                  <a class="moj-task-list__task-name" href="accommodation-service/further-information">Further information for service provider</a>
+                {% else %}
+                  <span class="app-task-list__task-name">
+                    Further information for service provider
+                  </span>
+                {% endif %}
+              </li>
+            </ul>
+          </li>
 
-        <li>
-          {% if data["social-inclusion-more-information-completed"] %}
-            <strong class="govuk-tag govuk-tag app-task-list__tag">
-              completed
-            </strong>
-          {% elseif data["social-inclusion-sentence"] %}
-            <strong class="govuk-tag govuk-tag app-task-list__tag">
-              in progress
-            </strong>
-          {% elseif data["needs-and-requirements-completed"] %}
-            <strong class="govuk-tag govuk-tag--grey app-task-list__tag">
-              not started
-            </strong>
-          {% else %}
-            <strong class="govuk-tag govuk-tag--grey app-task-list__tag">
-              cannot start yet
-            </strong>
-          {% endif %}
+          <li>
+            {% if data["social-inclusion-more-information-completed"] %}
+              <strong class="govuk-tag govuk-tag app-task-list__tag">
+                completed
+              </strong>
+            {% elseif data["social-inclusion-sentence"] %}
+              <strong class="govuk-tag govuk-tag app-task-list__tag">
+                in progress
+              </strong>
+            {% elseif data["needs-and-requirements-completed"] %}
+              <strong class="govuk-tag govuk-tag--grey app-task-list__tag">
+                not started
+              </strong>
+            {% else %}
+              <strong class="govuk-tag govuk-tag--grey app-task-list__tag">
+                cannot start yet
+              </strong>
+            {% endif %}
 
-          <h2 class="moj-task-list__section">
-            <span class="moj-task-list__section-number">6.
-            </span>
-            Social inclusion referral
-          </h2>
-          <ul class="moj-task-list__items">
-            <li class="moj-task-list__item">
-              {% if data["needs-and-requirements-completed"] %}
-                <a class="moj-task-list__task-name" href="social-inclusion-service/select-sentence">Select the relevant sentence for the social inclusion service referral</a>
-              {% else %}
-                <span class="app-task-list__task-name">
-                  Select relevant sentence
-                </span>
-              {% endif %}
-            </li>
-            <li class="moj-task-list__item">
-              {% if data["social-inclusion-sentence"] %}
-                <a class="moj-task-list__task-name" href="social-inclusion-service/desired-outcomes">What are the desired outcomes for the social inclusion service?</a>
-              {% else %}
-                <span class="app-task-list__task-name">
-                  Select desired outcomes
-                </span>
-              {% endif %}
-            </li>
-            <li class="moj-task-list__item">
-              {% if data["social-inclusion-desired-outcomes"] %}
-                <a class="moj-task-list__task-name" href="social-inclusion-service/complexity-level">What is the required complexity level for the social inclusion service?</a>
-              {% else %}
-                <span class="app-task-list__task-name">
-                  Select required complexity level
-                </span>
-              {% endif %}
-            </li>
-            <li class="moj-task-list__item">
-              {% if data["social-inclusion-complexity"] %}
-                <a class="moj-task-list__task-name" href="social-inclusion-service/completion-date">Enter completion date</a>
-              {% else %}
-                <span class="app-task-list__task-name">
-                  Enter completion date
-                </span>
-              {% endif %}
-            </li>
-            <li class="moj-task-list__item">
-              {% if data["social-inclusion-date-year"] %}
-                <a class="moj-task-list__task-name" href="social-inclusion-service/rar-days">Enter RAR days used</a>
-              {% else %}
-                <span class="app-task-list__task-name">
-                  Enter RAR days used
-                </span>
-              {% endif %}
-            </li>
-            <li class="moj-task-list__item">
-              {% if data["social-inclusion-using-rar-days"] %}
-                <a class="moj-task-list__task-name" href="social-inclusion-service/further-information">Further information for service provider</a>
-              {% else %}
-                <span class="app-task-list__task-name">
-                  Further information for service provider
-                </span>
-              {% endif %}
-            </li>
-          </ul>
-        </li>
-        <li>
+            <h2 class="moj-task-list__section">
+              <span class="moj-task-list__section-number">6.
+              </span>
+              Social inclusion referral
+            </h2>
+            <ul class="moj-task-list__items">
+              <li class="moj-task-list__item">
+                {% if data["needs-and-requirements-completed"] %}
+                  <a class="moj-task-list__task-name" href="social-inclusion-service/select-sentence">Select the relevant sentence for the social inclusion service referral</a>
+                {% else %}
+                  <span class="app-task-list__task-name">
+                    Select relevant sentence
+                  </span>
+                {% endif %}
+              </li>
+              <li class="moj-task-list__item">
+                {% if data["social-inclusion-sentence"] %}
+                  <a class="moj-task-list__task-name" href="social-inclusion-service/desired-outcomes">What are the desired outcomes for the social inclusion service?</a>
+                {% else %}
+                  <span class="app-task-list__task-name">
+                    Select desired outcomes
+                  </span>
+                {% endif %}
+              </li>
+              <li class="moj-task-list__item">
+                {% if data["social-inclusion-desired-outcomes"] %}
+                  <a class="moj-task-list__task-name" href="social-inclusion-service/complexity-level">What is the required complexity level for the social inclusion service?</a>
+                {% else %}
+                  <span class="app-task-list__task-name">
+                    Select required complexity level
+                  </span>
+                {% endif %}
+              </li>
+              <li class="moj-task-list__item">
+                {% if data["social-inclusion-complexity"] %}
+                  <a class="moj-task-list__task-name" href="social-inclusion-service/completion-date">Enter completion date</a>
+                {% else %}
+                  <span class="app-task-list__task-name">
+                    Enter completion date
+                  </span>
+                {% endif %}
+              </li>
+              <li class="moj-task-list__item">
+                {% if data["social-inclusion-date-year"] %}
+                  <a class="moj-task-list__task-name" href="social-inclusion-service/rar-days">Enter RAR days used</a>
+                {% else %}
+                  <span class="app-task-list__task-name">
+                    Enter RAR days used
+                  </span>
+                {% endif %}
+              </li>
+              <li class="moj-task-list__item">
+                {% if data["social-inclusion-using-rar-days"] %}
+                  <a class="moj-task-list__task-name" href="social-inclusion-service/further-information">Further information for service provider</a>
+                {% else %}
+                  <span class="app-task-list__task-name">
+                    Further information for service provider
+                  </span>
+                {% endif %}
+              </li>
+            </ul>
+          </li>
+
+        {% endif %}
+
+          <li>
           {% if data["social-inclusion-more-information-completed"] and data["accommodation-more-info-completed"] and data["responsible-officer-information-completed"] %}
             <strong class="govuk-tag govuk-tag--grey app-task-list__tag">
               not started

--- a/app/views/sprint-6/book-and-manage/make-a-referral/referral-task-list.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/referral-task-list.html
@@ -213,10 +213,10 @@
             <ul class="moj-task-list__items">
               <li class="moj-task-list__item">
                 {% if data["needs-and-requirements-completed"] %}
-                  <a class="moj-task-list__task-name" href="accommodation-service/select-sentence">Select relevant sentence</a>
+                  <a class="moj-task-list__task-name" href="accommodation-service/select-sentence">Select the relevant sentence for the accommodation service referral</a>
                 {% else %}
                   <span class="app-task-list__task-name">
-                    Select relevant sentence
+                    Select relevant sentence for the accommodation service referral
                   </span>
                 {% endif %}
               </li>
@@ -298,7 +298,7 @@
                   <a class="moj-task-list__task-name" href="social-inclusion-service/select-sentence">Select the relevant sentence for the social inclusion service referral</a>
                 {% else %}
                   <span class="app-task-list__task-name">
-                    Select relevant sentence
+                    Select relevant sentence for the social inclusion service referral
                   </span>
                 {% endif %}
               </li>
@@ -322,10 +322,10 @@
               </li>
               <li class="moj-task-list__item">
                 {% if data["social-inclusion-complexity"] %}
-                  <a class="moj-task-list__task-name" href="social-inclusion-service/completion-date">Enter completion date</a>
+                  <a class="moj-task-list__task-name" href="social-inclusion-service/completion-date">What date does the social inclusion service need to be completed by?</a>
                 {% else %}
                   <span class="app-task-list__task-name">
-                    Enter completion date
+                    What date does the social inclusion service need to be completed by?
                   </span>
                 {% endif %}
               </li>

--- a/app/views/sprint-6/book-and-manage/make-a-referral/referral-task-list.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/referral-task-list.html
@@ -180,6 +180,14 @@
 
         {% if data["found-interventions"] %}
           <li>
+            <h2 class="moj-task-list__section">
+              <span class="moj-task-list__section-number">5.
+              </span>
+              Add intervention referrals detail
+            </h2>
+          </li>
+
+          <li class="govuk-!-margin-left-5">
             {% if data["accommodation-more-info-completed"] %}
               <strong class="govuk-tag govuk-tag app-task-list__tag">
                 completed
@@ -198,7 +206,7 @@
               </strong>
             {% endif %}
             <h2 class="moj-task-list__section">
-              <span class="moj-task-list__section-number">5.
+              <span class="moj-task-list__section-number govuk-!-padding-right-2">5.1.
               </span>
               Accommodation referral
             </h2>
@@ -260,7 +268,7 @@
             </ul>
           </li>
 
-          <li>
+          <li class="govuk-!-margin-left-5">
             {% if data["social-inclusion-more-information-completed"] %}
               <strong class="govuk-tag govuk-tag app-task-list__tag">
                 completed
@@ -280,7 +288,7 @@
             {% endif %}
 
             <h2 class="moj-task-list__section">
-              <span class="moj-task-list__section-number">6.
+              <span class="moj-task-list__section-number govuk-!-padding-right-2">5.2.
               </span>
               Social inclusion referral
             </h2>
@@ -342,6 +350,24 @@
             </ul>
           </li>
 
+        {% else %}
+          <li>
+            <strong class="govuk-tag govuk-tag--grey app-task-list__tag">
+              cannot start yet
+            </strong>
+            <h2 class="moj-task-list__section">
+              <span class="moj-task-list__section-number">5.
+              </span>
+              Add intervention referrals detail
+            </h2>
+            <ul class="moj-task-list__items">
+              <li class="moj-task-list__item">
+                <span class="app-task-list__task-name">
+                  Selected interventions will appear here.
+                </span>
+              </li>
+            </ul>
+          </li>
         {% endif %}
 
           <li>
@@ -355,7 +381,7 @@
             </strong>
           {% endif %}
           <h2 class="moj-task-list__section">
-            <span class="moj-task-list__section-number">7.
+            <span class="moj-task-list__section-number">6.
             </span>
             Check your answers
           </h2>


### PR DESCRIPTION
# What's new

Now that the list of interventions isn't known until the Find task has been completed, we now only show the intervention details tasks in Refer after Find has been done. We turn the intervention details into a single task with subsections, to allow the task list to maintain a consistent numbering even before the number of interventions is known.

# Screenshots

## Before finding interventions

![image](https://user-images.githubusercontent.com/53756884/96714111-970bf780-1399-11eb-9784-5ca1f484f4f7.png)

## After finding interventions

![image](https://user-images.githubusercontent.com/53756884/96714191-b3a82f80-1399-11eb-8b28-5301c4d2c731.png)