### PR TITLE
[Sprint 6] Post-handover tweaks

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -28,6 +28,15 @@ $govuk-assets-path: '/govuk/assets/';
   padding: govuk-spacing(5) !important;
 }
 
+.intervention-added {
+  background-color: #cdffcf !important;
+  color: #1a1818 !important;
+  text-transform: none !important;
+  width: 95% !important;
+  margin-bottom: govuk-spacing(5) !important;
+  letter-spacing: normal !important;
+}
+
 .group-by {
   display: flex;
 

--- a/app/routes/sprint-6/findAReferralRoutes.js
+++ b/app/routes/sprint-6/findAReferralRoutes.js
@@ -70,6 +70,7 @@ router.post("/:interventionId/details", function (req, res) {
     {
       intervention: intervention,
       selectedInterventions: selectedInterventions,
+      interventionAdded: true,
     }
   );
 });

--- a/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/complexity-level.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/complexity-level.html
@@ -25,19 +25,19 @@
           <div class="govuk-radios">
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="low" name="accommodation-complexity" type="radio" value="Low complexity" {{ checked("accommodation-complexity", "Low complexity") }}>
-              <label class="govuk-label govuk-radios__label" for="accommodation-complexity">
+              <label class="govuk-label govuk-radios__label" for="low">
                 Low complexity<br>Service User has some capacity and means to secure and/or maintain suitable accommodation but requires some support and guidance to do so.
               </label>
             </div>
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="medium" name="accommodation-complexity" type="radio" value="Medium complexity" {{ checked("accommodation-complexity", "Medium complexity") }}>
-              <label class="govuk-label govuk-radios__label" for="accommodation-complexity-2">
+              <label class="govuk-label govuk-radios__label" for="medium">
                 Medium complexity<br>Service User is at risk of homelessness/is homeless, or will be on release from prison. Service User has had some success in maintaining atenancy but may have additional needs e.g. Learning Difficulties and/or Learning Disabilities or other challenges currently.
               </label>
             </div>
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="medium" name="accommodation-complexity" type="radio" value="High complexity" {{ checked("accommodation-complexity", "High complexity") }}>
-              <label class="govuk-label govuk-radios__label" for="accommodation-complexity-3">
+              <label class="govuk-label govuk-radios__label" for="high">
                 High complexity<br>Service User is homeless or in temporary/unstable accommodation, or will be on release from prison. Service User has poor accommodation history, complex needs and limited skills to secure or sustain a tenancy.
               </label>
             </div>

--- a/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/select-sentence.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/select-sentence.html
@@ -25,15 +25,15 @@
             </legend>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="wild-birds" name="accommodation-sentence" type="radio" value="Wild birds" {{ checked("accommodation-sentence", "Wild birds") }}>
-                <label class="govuk-label govuk-radios__label" for="accommodation-sentence">
-                  Wild birds protection act<br>Sub category: Wild birds protection act, 1900<br>Date: 01/01/2020<br>Order: Suspended sentence
+                <input class="govuk-radios__input" id="burglary" name="accommodation-sentence" type="radio" value="Burglary" {{ checked("accommodation-sentence", "Wild birds") }}>
+                <label class="govuk-label govuk-radios__label" for="burglary">
+                  Burglary<br>Sub category: Theft act, 1968<br>Date: 01/04/2021<br>Order: Suspended sentence
                 </label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="armed-robbery" name="accommodation-sentence" type="radio" value="Armed robbery" {{ checked("accommodation-sentence", "Armed robbery") }}>
-                <label class="govuk-label govuk-radios__label" for="accommodation-sentence-2">
-                  Armed robbery<br>Sub category: Wild birds protection act, 1900<br>Date: 01/01/2020<br>Order: Suspended sentence
+                <label class="govuk-label govuk-radios__label" for="armed-robbery">
+                  Armed robbery<br>Sub category: Serious crime act, 1969<br>Date: 01/05/2025<br>Order: Suspended sentence
                 </label>
               </div>
             </fieldset>

--- a/app/views/sprint-6/book-and-manage/make-a-referral/confirmation.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/confirmation.html
@@ -27,7 +27,7 @@
       </p>
 
       <h2 class="govuk-heading-m">What happens next</h2>
-      <p>They will be in contact soon.</p>
+      <p>Harmony Living will be in contact within 10 days to schedule the assessment.</p>
       <p><a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html">What did you think of this service?</a> (takes 30 seconds)</p>
     </div>
   </div>

--- a/app/views/sprint-6/book-and-manage/make-a-referral/find-an-intervention/details.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/find-an-intervention/details.html
@@ -23,6 +23,12 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
+      {% if interventionAdded %}
+        <strong class="govuk-tag intervention-added">
+          Intervention added to shortlist
+        </strong>
+      {% endif %}
+
       {% if intervention.title == "Accommodation" %}
         <h1 class="govuk-heading-xl">Accommodation</h1>
         <p>

--- a/app/views/sprint-6/book-and-manage/make-a-referral/find-an-intervention/find-multi-select.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/find-an-intervention/find-multi-select.html
@@ -40,7 +40,7 @@
 
       <form action="results">
         <div class="govuk-form-group">
-          <label for="location" class="govuk-label">Location</label>
+          <label for="location" class="govuk-label">Alex's Location</label>
           <input id="location" class="govuk-input" name="location" placeholder="For example London" value="SY16 1AQ">
         </div>
 

--- a/app/views/sprint-6/book-and-manage/make-a-referral/find-an-intervention/results.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/find-an-intervention/results.html
@@ -79,11 +79,8 @@
 
     <div class="govuk-grid-column-three-quarters">
       <p>
-        <span class="govuk-body-l">55</span>
-        interventions found containing
-        <strong>xxxxxx</strong>
-        in
-        <strong>yyyyyy</strong>
+        <span class="govuk-body-l">3</span>
+        interventions matching your criteria.
       </p>
 
       <section>

--- a/app/views/sprint-6/book-and-manage/make-a-referral/referral-start.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/referral-start.html
@@ -28,9 +28,9 @@
 
       <div>
         <h2 class="govuk-heading-m">
-          In progress referrals
+          Draft referrals
         </h2>
-        <p>You do not have any in progress referrals at the moment.</p>
+        <p>You do not have any draft referrals at the moment.</p>
       </div>
     </div>
   {% endblock %}

--- a/app/views/sprint-6/book-and-manage/make-a-referral/responsible-officer-information.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/responsible-officer-information.html
@@ -45,6 +45,14 @@
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key govuk-!-width-one-third">
+              Team
+            </dt>
+            <dd class="govuk-summary-list__value">
+              OMU Team 1
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key govuk-!-width-one-third">
               Office address
             </dt>
             <dd class="govuk-summary-list__value">

--- a/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/complexity-level.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/complexity-level.html
@@ -25,21 +25,21 @@
           <div class="govuk-radios">
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="low" name="social-inclusion-complexity" type="radio" value="Low complexity" {{ checked("social-inclusion-complexity", "Low complexity") }}>
-              <label class="govuk-label govuk-radios__label" for="social-inclusion-complexity">
+              <label class="govuk-label govuk-radios__label" for="low">
                 Low complexity<br>
                 [up to 4 Sessions (pre-release virtual contact)] Service User has a low risk of reoffending. Service User has limited family support or engagement with community services and there may be barriers to achieving community integration.
               </label>
             </div>
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="medium" name="social-inclusion-complexity" type="radio" value="Medium complexity" {{ checked("social-inclusion-complexity", "Medium complexity") }}>
-              <label class="govuk-label govuk-radios__label" for="social-inclusion-complexity-2">
+              <label class="govuk-label govuk-radios__label" for="medium">
                 Medium complexity<br>
                 [up to 8 sessions (Including up to 2 pre-release face-to- face contacts)] Service User has medium risk of reoffending. Service User has limited family support or engagement with community services and there may be barriers to achieving community integration. Service User has additional vulnerabilities requiring support through release and may have a pattern of non-compliance, e.g. recalls or failure to attend appointments.
               </label>
             </div>
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="medium" name="social-inclusion-complexity" type="radio" value="High complexity" {{ checked("social-inclusion-complexity", "High complexity") }}>
-              <label class="govuk-label govuk-radios__label" for="social-inclusion-complexity-3">
+              <input class="govuk-radios__input" id="high" name="social-inclusion-complexity" type="radio" value="High complexity" {{ checked("social-inclusion-complexity", "High complexity") }}>
+              <label class="govuk-label govuk-radios__label" for="high">
                 High complexity<br>
                 [(up to 12 sessions (including up to 3 pre-release face-to-face contacts)] Service User has high risk of reoffending. Service User has limited family support, a lack of social networks or minimal engagement with community services and there may be barriers to achieving community integration. Service User has additional vulnerabilities requiring support throughout release with a pattern of non-compliance and a high likelihood of non-compliance in early weeks of release, e.g. recalls or failure to attend appointments.
               </label>

--- a/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/complexity-level.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/complexity-level.html
@@ -26,22 +26,33 @@
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="low" name="social-inclusion-complexity" type="radio" value="Low complexity" {{ checked("social-inclusion-complexity", "Low complexity") }}>
               <label class="govuk-label govuk-radios__label" for="low">
-                Low complexity<br>
-                [up to 4 Sessions (pre-release virtual contact)] Service User has a low risk of reoffending. Service User has limited family support or engagement with community services and there may be barriers to achieving community integration.
+                <h2 class="govuk-body-m govuk-!-margin-bottom-1">Low complexity [up to 4 sessions (pre-release virtual contact)]</h2>
+                <ul class="govuk-list govuk-list--bullet">
+                  <li>Service User has a low risk of reoffending.</li>
+                  <li>Service User has limited family support or engagement with community services and there may be barriers to achieving community integration.</li>
+                </ul>
               </label>
             </div>
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="medium" name="social-inclusion-complexity" type="radio" value="Medium complexity" {{ checked("social-inclusion-complexity", "Medium complexity") }}>
               <label class="govuk-label govuk-radios__label" for="medium">
-                Medium complexity<br>
-                [up to 8 sessions (Including up to 2 pre-release face-to- face contacts)] Service User has medium risk of reoffending. Service User has limited family support or engagement with community services and there may be barriers to achieving community integration. Service User has additional vulnerabilities requiring support through release and may have a pattern of non-compliance, e.g. recalls or failure to attend appointments.
+                <h2 class="govuk-body-m govuk-!-margin-bottom-1">Medium complexity [up to 8 sessions (including up to 2 pre-release face-to- face contacts)]</h2>
+                <ul class="govuk-list govuk-list--bullet">
+                  <li>Service User has medium risk of reoffending.</li>
+                  <li>Service User has limited family support or engagement with community services and there may be barriers to achieving community integration.</li>
+                  <li>Service User has additional vulnerabilities requiring support through release and may have a pattern of non-compliance, e.g. recalls or failure to attend appointments.</li>
+                </ul>
               </label>
             </div>
             <div class="govuk-radios__item">
               <input class="govuk-radios__input" id="high" name="social-inclusion-complexity" type="radio" value="High complexity" {{ checked("social-inclusion-complexity", "High complexity") }}>
               <label class="govuk-label govuk-radios__label" for="high">
-                High complexity<br>
-                [(up to 12 sessions (including up to 3 pre-release face-to-face contacts)] Service User has high risk of reoffending. Service User has limited family support, a lack of social networks or minimal engagement with community services and there may be barriers to achieving community integration. Service User has additional vulnerabilities requiring support throughout release with a pattern of non-compliance and a high likelihood of non-compliance in early weeks of release, e.g. recalls or failure to attend appointments.
+                <h2 class="govuk-body-m govuk-!-margin-bottom-1">High complexity [(up to 12 sessions (including up to 3 pre-release face-to-face contacts)]</h2>
+                <ul class="govuk-list govuk-list--bullet">
+                  <li>Service User has high risk of reoffending.</li>
+                  <li>Service User has limited family support, a lack of social networks or minimal engagement with community services and there may be barriers to achieving community integration.</li>
+                  <li>Service User has additional vulnerabilities requiring support throughout release with a pattern of non-compliance and a high likelihood of non-compliance in early weeks of release, e.g. recalls or failure to attend appointments.</li>
+                </ul>
               </label>
             </div>
           </fieldset>

--- a/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/select-sentence.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/select-sentence.html
@@ -24,15 +24,15 @@
           </legend>
           <div class="govuk-radios">
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="wild-birds" name="social-inclusion-sentence" type="radio" value="Wild birds" {{ checked("social-inclusion-sentence", "Wild birds") }}>
-              <label class="govuk-label govuk-radios__label" for="social-inclusion-sentence">
-                Wild birds protection act<br>Sub category: Wild birds protection act, 1900<br>Date: 01/01/2020<br>Order: Suspended sentence
+              <input class="govuk-radios__input" id="burglary" name="accommodation-sentence" type="radio" value="Burglary" {{ checked("accommodation-sentence", "Wild birds") }}>
+              <label class="govuk-label govuk-radios__label" for="burglary">
+                Burglary<br>Sub category: Theft act, 1968<br>Date: 01/04/2021<br>Order: Suspended sentence
               </label>
             </div>
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="armed-robbery" name="social-inclusion-sentence" type="radio" value="Armed robbery"  {{ checked("social-inclusion-sentence", "Armed robbery") }}>
-              <label class="govuk-label govuk-radios__label" for="social-inclusion-sentence-2">
-                Armed robbery<br>Sub category: Wild birds protection act, 1900<br>Date: 01/01/2020<br>Order: Suspended sentence
+              <input class="govuk-radios__input" id="armed-robbery" name="accommodation-sentence" type="radio" value="Armed robbery" {{ checked("accommodation-sentence", "Armed robbery") }}>
+              <label class="govuk-label govuk-radios__label" for="armed-robbery">
+                Armed robbery<br>Sub category: Serious crime act, 1969<br>Date: 01/05/2025<br>Order: Suspended sentence
               </label>
             </div>
         </fieldset>

--- a/app/views/sprint-6/monitor/cases/action-plan-review.html
+++ b/app/views/sprint-6/monitor/cases/action-plan-review.html
@@ -127,33 +127,27 @@
                     <div class="govuk-radios__item">
                       <input class="govuk-radios__input" id="approve-action-plan" name="approve-action-plan" value="yes" type="radio" data-aria-controls="conditional-approve-action-plan">
                       <label class="govuk-label govuk-radios__label" for="approve-action-plan">
-                        Yes, approved.
+                        Yes
                       </label>
                     </div>
                     <div class="govuk-radios__item">
                       <input class="govuk-radios__input" id="reject-action-plan" name="approve-action-plan" value="no" type="radio" data-aria-controls="conditional-reject-action-plan">
                       <label class="govuk-label govuk-radios__label" for="reject-action-plan">
-                        No, I would like to reject it and make some comments.
+                        Suggest changes
                       </label>
                     </div>
                     <div class="conditional-section govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-reject-action-plan">
                       <div class="govuk-form-group">
                         <label class="govuk-label" for="reasons-for-rejection">
-                          Please enter the reasons why you reject it:
+                          Suggested changes:
                         </label>
                         <textarea class="govuk-textarea" id="reasons-for-rejection" rows="5" name="reasons-for-rejection"></textarea>
                       </div>
-
-                      <button class="govuk-button" data-module="govuk-button">
-                        Reject
-                      </button>
                     </div>
 
-                    <div class="conditional-section govuk-radios__conditional govuk-radios__conditional--hidden govuk-!-margin-top-6" id="conditional-approve-action-plan">
-                      <button class="govuk-button" data-module="govuk-button">
-                        Approve
-                      </button>
-                    </div>
+                    <button class="govuk-button govuk-!-margin-top-5" data-module="govuk-button">
+                      Save and continue
+                    </button>
                   </div>
                 </fieldset>
 

--- a/app/views/sprint-6/monitor/cases/action-plan-review.html
+++ b/app/views/sprint-6/monitor/cases/action-plan-review.html
@@ -81,66 +81,36 @@
                   <td class="govuk-table__cell">Session 1</td>
                   <td class="govuk-table__cell">07/10/20</td>
                   <td class="govuk-table__cell">{{ intervention.assignedCaseworker }}</td>
-                  <td class="govuk-table__cell">
-                    <strong class="govuk-tag">
-                      completed
-                    </strong>
-                  </td>
-                  <td class="govuk-table__cell">
-                    <a class="govuk-link" href="#">View</a>
-                  </td>
+                  <td class="govuk-table__cell"></td>
+                  <td class="govuk-table__cell"></td>
                 </tr>
                 <tr class="govuk-table__row">
                   <td class="govuk-table__cell">Session 2</td>
                   <td class="govuk-table__cell">14/10/20</td>
                   <td class="govuk-table__cell">{{ intervention.assignedCaseworker }}</td>
-                  <td class="govuk-table__cell">
-                    <strong class="govuk-tag">
-                      completed
-                    </strong>
-                  </td>
-                  <td class="govuk-table__cell">
-                    <a class="govuk-link" href="#">View</a>
-                  </td>
+                  <td class="govuk-table__cell"></td>
+                  <td class="govuk-table__cell"></td>
                 </tr>
                 <tr class="govuk-table__row">
                   <td class="govuk-table__cell">Session 3</td>
                   <td class="govuk-table__cell">21/10/20</td>
                   <td class="govuk-table__cell">{{ intervention.assignedCaseworker }}</td>
-                  <td class="govuk-table__cell">
-                    <strong class="govuk-tag">
-                      completed
-                    </strong>
-                  </td>
-                  <td class="govuk-table__cell">
-                    <a class="govuk-link" href="#">View</a>
-                  </td>
+                  <td class="govuk-table__cell"></td>
+                  <td class="govuk-table__cell"></td>
                 </tr>
                 <tr class="govuk-table__row">
                   <td class="govuk-table__cell">Session 4</td>
                   <td class="govuk-table__cell">29/10/20</td>
                   <td class="govuk-table__cell">{{ intervention.assignedCaseworker }}</td>
-                  <td class="govuk-table__cell">
-                    <strong class="govuk-tag">
-                      completed
-                    </strong>
-                  </td>
-                  <td class="govuk-table__cell">
-                    <a class="govuk-link" href="#">View</a>
-                  </td>
+                  <td class="govuk-table__cell"></td>
+                  <td class="govuk-table__cell"></td>
                 </tr>
                 <tr class="govuk-table__row">
                   <td class="govuk-table__cell">Session 5</td>
                   <td class="govuk-table__cell">06/11/20</td>
                   <td class="govuk-table__cell">{{ intervention.assignedCaseworker }}</td>
-                  <td class="govuk-table__cell">
-                    <strong class="govuk-tag">
-                      completed
-                    </strong>
-                  </td>
-                  <td class="govuk-table__cell">
-                    <a class="govuk-link" href="#">View</a>
-                  </td>
+                  <td class="govuk-table__cell"></td>
+                  <td class="govuk-table__cell"></td>
                 </tr>
               </tbody>
             </table>


### PR DESCRIPTION
## Changes in this PR

Based on feedback during the handover of the protoype:
- Change "in progress" referrals to "draft"
- Update Find search text to add "Service user location" for clarity
- Add team to responsible officer page
- Add more realistic sentences (no more Wild Birds)
- Tweak complexity levels
- Update confirmation text to provide time estimate
- Remove "completed" from action plan and actions
- Update action plan approval text
- Add notification when intervention selected 