### PR TITLE
[Sprint 6]: Fix select sentence

### DIFF
--- a/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/select-sentence.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/accommodation-service/select-sentence.html
@@ -25,7 +25,7 @@
             </legend>
             <div class="govuk-radios">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="burglary" name="accommodation-sentence" type="radio" value="Burglary" {{ checked("accommodation-sentence", "Wild birds") }}>
+                <input class="govuk-radios__input" id="burglary" name="accommodation-sentence" type="radio" value="Burglary" {{ checked("accommodation-sentence", "Burglary") }}>
                 <label class="govuk-label govuk-radios__label" for="burglary">
                   Burglary<br>Sub category: Theft act, 1968<br>Date: 01/04/2021<br>Order: Suspended sentence
                 </label>

--- a/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/select-sentence.html
+++ b/app/views/sprint-6/book-and-manage/make-a-referral/social-inclusion-service/select-sentence.html
@@ -24,13 +24,13 @@
           </legend>
           <div class="govuk-radios">
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="burglary" name="accommodation-sentence" type="radio" value="Burglary" {{ checked("accommodation-sentence", "Wild birds") }}>
+              <input class="govuk-radios__input" id="burglary" name="social-inclusion-sentence" type="radio" value="Burglary" {{ checked("social-inclusion-sentence", "Burglary") }}>
               <label class="govuk-label govuk-radios__label" for="burglary">
                 Burglary<br>Sub category: Theft act, 1968<br>Date: 01/04/2021<br>Order: Suspended sentence
               </label>
             </div>
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="armed-robbery" name="accommodation-sentence" type="radio" value="Armed robbery" {{ checked("accommodation-sentence", "Armed robbery") }}>
+              <input class="govuk-radios__input" id="armed-robbery" name="social-inclusion-sentence" type="radio" value="Armed robbery" {{ checked("social-inclusion-sentence", "Armed robbery") }}>
               <label class="govuk-label govuk-radios__label" for="armed-robbery">
                 Armed robbery<br>Sub category: Serious crime act, 1969<br>Date: 01/05/2025<br>Order: Suspended sentence
               </label>


### PR DESCRIPTION
 ## Changes in this PR
- Fix `name` attribute on social inclusion sentence
This was copy/pasted from Accommodation when updated last without
changing the `name`, so it was being set to the old value (and not setting
one for social inclusion)
- Fix incorrect "checked" value on accommodation.
