### PR TITLE
The end-to-end Monitor journey can be demoed with Alex River

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -2004,7 +2004,6 @@ module.exports = {
             id: "0",
             name: "Accommodation",
             providerName: "Harmony Living",
-            assignedCaseworker: "Jenny Thompson",
             monitor: {
               actionPlanSubmitted: false,
               actionPlanApproved: false,

--- a/app/routes/sprint-7/monitorRoutes.js
+++ b/app/routes/sprint-7/monitorRoutes.js
@@ -229,4 +229,40 @@ router.post(
   }
 );
 
+router.get(
+  "/cases/:referralNumber/interventions/:interventionId/fast-forward",
+  (req, res) => {
+    const toState = req.query.to;
+
+    const referralNumber = req.params.referralNumber;
+    const interventionId = req.params.interventionId;
+
+    const referral = findReferral(
+      req.session.data.sprint7.referrals,
+      referralNumber
+    );
+
+    const intervention = referral.interventions.find(
+      (intervention) => interventionId === intervention.id
+    );
+
+    switch (toState) {
+      case "assignedCaseworker":
+        intervention.assignedCaseworker = "Jenny Thompson";
+        break;
+      case "initialAssessmentCompleted":
+        intervention.monitor.initialAssessmentCompleted = true;
+        break;
+      case "actionPlanSubmitted":
+        intervention.monitor.actionPlanSubmitted = true;
+        break;
+      case "inProgress":
+        intervention.monitor.inProgress = true;
+        break;
+    }
+
+    res.redirect(`/sprint-7/monitor/cases/${req.params.referralNumber}/interventions/${req.params.interventionId}`);
+  }
+);
+
 module.exports = router;

--- a/app/views/sprint-7/monitor/cases/intervention-sidebar.html
+++ b/app/views/sprint-7/monitor/cases/intervention-sidebar.html
@@ -66,3 +66,28 @@
     </li>
   </ul>
 </div>
+
+{% if showFastForwardLinks %}
+  {% set fastForwardToState = null %}
+  {% set fastForwardText = null %}
+
+  {% if not intervention.assignedCaseworker %}
+    {% set fastForwardToState = "assignedCaseworker" %}
+    {% set fastForwardText = "caseworker assigned" %}
+  {% elif not intervention.monitor.initialAssessmentCompleted %}
+    {% set fastForwardToState = "initialAssessmentCompleted" %}
+    {% set fastForwardText = "initial assessment completed" %}
+  {% elif not intervention.monitor.actionPlanSubmitted %}
+    {% set fastForwardToState = "actionPlanSubmitted" %}
+    {% set fastForwardText = "action plan submitted" %}
+  {% elif intervention.monitor.actionPlanApproved and not intervention.monitor.inProgress %}
+    {% set fastForwardToState = "inProgress" %}
+    {% set fastForwardText = "in progress" %}
+  {% endif %}
+
+  {% if fastForwardToState != null %}
+    <p class="govuk-body">
+    <a class="govuk-link govuk-link--app-fast-forward-subtler" href="/sprint-7/monitor/cases/{{referral.reference}}/interventions/{{intervention.id}}/fast-forward?to={{fastForwardToState}}">Demo: fast-forward to {{ fastForwardText }}</a>
+    </p>
+  {% endif %}
+{% endif %}

--- a/app/views/sprint-7/monitor/cases/intervention.html
+++ b/app/views/sprint-7/monitor/cases/intervention.html
@@ -19,6 +19,7 @@
         </h1>
         {% set currentPage = intervention.name %}
         {% include "./side-navigation.html" %}
+        {% set showFastForwardLinks = true %}
         {% include "./intervention-sidebar.html" %}
       </div>
 


### PR DESCRIPTION
# What's new

This adds fast-forward links to Monitor so that we can demo Alex River's journey. It also changes Alex's data so that he starts from the very first state (no caseworker asssigned).

# Recording of journey

[Attached to Trello card.](https://trello.com/c/n4ErVELK/462-monitor-should-allow-alex-rivers-journey-to-be-demonstrated-end-to-end)