### PR TITLE
Fix width after POST to Monitor intervention page

### DIFF
--- a/app/routes/sprint-7/monitorRoutes.js
+++ b/app/routes/sprint-7/monitorRoutes.js
@@ -218,14 +218,7 @@ router.post(
 
     intervention.monitor.actionPlanApproved = actionPlanApproved;
 
-    const serviceUser = referral ? referral.serviceUser : {};
-
-    res.render("sprint-7/monitor/cases/intervention", {
-      referral: referral,
-      intervention: intervention,
-      serviceUser: serviceUser,
-      currentPage: intervention.name,
-    });
+    res.redirect(`/sprint-7/monitor/cases/${referralNumber}/interventions/${interventionId}`);
   }
 );
 


### PR DESCRIPTION
Make the POST to /cases/:referralNumber/interventions/:interventionId
redirect instead of rendering. The extraWide flag only gets set for
GETs. In general, the usual pattern in web services seems to be "render
on a GET, redirect on a successful POST", so I think it's fine.