### PR TITLE
Add PP end of service report

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -2015,6 +2015,7 @@ module.exports = {
               initialAssessmentCompleted: false,
               awaitingPostSessionQuestionnaire: false,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2046,6 +2047,7 @@ module.exports = {
               initialAssessmentCompleted: false,
               awaitingPostSessionQuestionnaire: false,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2094,6 +2096,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: false,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2127,6 +2130,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: false,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2160,6 +2164,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: false,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2206,6 +2211,7 @@ module.exports = {
               initialAssessmentCompleted: false,
               awaitingPostSessionQuestionnaire: false,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2252,6 +2258,7 @@ module.exports = {
               initialAssessmentCompleted: false,
               awaitingPostSessionQuestionnaire: false,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2300,6 +2307,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: false,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2348,6 +2356,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: true,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2396,6 +2405,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: true,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2444,6 +2454,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: true,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2492,6 +2503,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: false,
               completed: true,
+              endOfServiceReportSubmitted: true
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2540,6 +2552,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: false,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2588,6 +2601,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: false,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2636,6 +2650,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: false,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2684,6 +2699,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: false,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2732,6 +2748,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: false,
               completed: false,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,
@@ -2780,6 +2797,7 @@ module.exports = {
               initialAssessmentCompleted: true,
               awaitingPostSessionQuestionnaire: true,
               completed: true,
+              endOfServiceReportSubmitted: false
             },
             actionPlanSubmitted: false,
             actionPlanApproved: false,

--- a/app/routes/sprint-7/monitorRoutes.js
+++ b/app/routes/sprint-7/monitorRoutes.js
@@ -199,33 +199,6 @@ router.get(
 );
 
 router.get(
-  "/cases/:referralNumber/interventions/:interventionId/action-plan",
-  (req, res) => {
-    const referralNumber = req.params.referralNumber;
-    const interventionId = req.params.interventionId;
-
-    const referral = findReferral(
-      req.session.data.sprint7.referrals,
-      referralNumber
-    );
-
-    const intervention = referral.interventions.find(
-      (intervention) => interventionId === intervention.id
-    );
-
-    const serviceUser = referral ? referral.serviceUser : {};
-
-    res.render("sprint-7/monitor/cases/action-plan-review", {
-      referral: referral,
-      intervention: intervention,
-      serviceUser: serviceUser,
-      currentPage: intervention.name,
-    });
-  }
-);
-
-
-router.get(
   "/cases/:referralNumber/interventions/:interventionId/end-of-service-report",
   (req, res) => {
     const referralNumber = req.params.referralNumber;

--- a/app/routes/sprint-7/monitorRoutes.js
+++ b/app/routes/sprint-7/monitorRoutes.js
@@ -198,6 +198,59 @@ router.get(
   }
 );
 
+router.get(
+  "/cases/:referralNumber/interventions/:interventionId/action-plan",
+  (req, res) => {
+    const referralNumber = req.params.referralNumber;
+    const interventionId = req.params.interventionId;
+
+    const referral = findReferral(
+      req.session.data.sprint7.referrals,
+      referralNumber
+    );
+
+    const intervention = referral.interventions.find(
+      (intervention) => interventionId === intervention.id
+    );
+
+    const serviceUser = referral ? referral.serviceUser : {};
+
+    res.render("sprint-7/monitor/cases/action-plan-review", {
+      referral: referral,
+      intervention: intervention,
+      serviceUser: serviceUser,
+      currentPage: intervention.name,
+    });
+  }
+);
+
+
+router.get(
+  "/cases/:referralNumber/interventions/:interventionId/end-of-service-report",
+  (req, res) => {
+    const referralNumber = req.params.referralNumber;
+    const interventionId = req.params.interventionId;
+
+    const referral = findReferral(
+      req.session.data.sprint7.referrals,
+      referralNumber
+    );
+
+    const intervention = referral.interventions.find(
+      (intervention) => interventionId === intervention.id
+    );
+
+    const serviceUser = referral ? referral.serviceUser : {};
+
+    res.render("sprint-7/monitor/cases/end-of-service-report", {
+      referral: referral,
+      intervention: intervention,
+      serviceUser: serviceUser,
+      currentPage: intervention.name,
+    });
+  }
+);
+
 router.post(
   "/cases/:referralNumber/interventions/:interventionId",
   (req, res) => {

--- a/app/views/sprint-7/monitor/cases/end-of-service-report.html
+++ b/app/views/sprint-7/monitor/cases/end-of-service-report.html
@@ -1,0 +1,79 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Manage intervention referrals
+{% endblock %}
+
+{% block header %}
+  {{ super() }}
+  {% include "../../includes/primary-navigation.html" %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
+          {{ serviceUser.name }}
+        </h1>
+        {% set currentPage = intervention.name %}
+        {% include "./side-navigation.html" %}
+        {% include "./intervention-sidebar.html" %}
+      </div>
+
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-tabs" data-module="govuk-tabs">
+          <ul class="govuk-tabs__list">
+            <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+              <a class="govuk-tabs__tab" href="/sprint-7/monitor/cases/{{referral.reference}}/interventions/{{intervention.id}}#progress">
+                Progress
+              </a>
+            </li>
+            <li class="govuk-tabs__list-item">
+              <a class="govuk-tabs__tab" href="/sprint-7/monitor/cases/{{referral.reference}}/interventions/{{intervention.id}}#paper-trail">
+                Paper trail
+              </a>
+            </li>
+            <li class="govuk-tabs__list-item">
+              <a class="govuk-tabs__tab" href="/sprint-7/monitor/cases/{{referral.reference}}/interventions/{{intervention.id}}#statistics">
+                Statistics
+              </a>
+            </li>
+          </ul>
+
+          <div class="govuk-tabs__panel govuk-tabs__panel" id="intervention-progress">
+            <a href="/sprint-7/monitor/cases/{{referral.reference}}/interventions/{{intervention.id}}#progress" class="govuk-back-link govuk-!-margin-bottom-6">Back to Progress</a>
+            <h2 class="govuk-heading-l">
+              End of service report
+            </h2>
+            <p class="govuk-body">
+              The service provider has created an end of service report for {{ serviceUser.name }}’s {{ intervention.name | lower }} intervention. Please view the following end of service report.
+            </p>
+
+            <h2 class="govuk-heading-m">Outcomes</h2>
+
+            <h2 class="govuk-heading-s">Outcome 1 - Achieved</h2>
+            <p class="govuk-body">
+              {{ serviceUser.name }} has achieved her outcome 1 perfectly.
+            </p>
+
+            <h2 class="govuk-heading-s">Outcome 2 - Partially achieved</h2>
+            <p class="govuk-body">
+              {{ serviceUser.name }} has partially achieved her outcome 2.
+            </p>
+
+            <h2 class="govuk-heading-m">Summary of all post-session feedback forms</h2>
+            <p class="govuk-body">
+              {{ serviceUser.name }} has completed all her sessions. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed finibus tellus vel erat consequat, ut sodales ligula dictum. Aliquam erat volutpat. Ut blandit convallis fringilla. Nullam convallis mauris at tristique laoreet.
+            </p>
+
+            <h2 class="govuk-heading-m">Service user's feedback on the intervention</h2>
+            <p class="govuk-body">
+              {{ serviceUser.name }} said lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed finibus tellus vel erat consequat, ut sodales ligula dictum. Aliquam erat volutpat. Ut blandit convallis fringilla. Nullam convallis mauris at tristique laoreet.
+            </p>
+
+          </div>
+        </div>
+      </div>
+    {% endblock %}

--- a/app/views/sprint-7/monitor/cases/end-of-service-report.html
+++ b/app/views/sprint-7/monitor/cases/end-of-service-report.html
@@ -55,12 +55,12 @@
 
             <h2 class="govuk-heading-s">Outcome 1 - Achieved</h2>
             <p class="govuk-body">
-              {{ serviceUser.name }} has achieved her outcome 1 perfectly.
+              {{ serviceUser.name }} has achieved outcome 1 perfectly.
             </p>
 
             <h2 class="govuk-heading-s">Outcome 2 - Partially achieved</h2>
             <p class="govuk-body">
-              {{ serviceUser.name }} has partially achieved her outcome 2.
+              {{ serviceUser.name }} has partially achieved outcome 2.
             </p>
 
             <h2 class="govuk-heading-m">Summary of all post-session feedback forms</h2>

--- a/app/views/sprint-7/monitor/cases/intervention.html
+++ b/app/views/sprint-7/monitor/cases/intervention.html
@@ -127,7 +127,7 @@
                       {% endif %}
                     </td>
                     <td class="govuk-table__cell">
-                      <a href="{{intervention.id}}/action-plan" class="govuk-link">View</td>
+                      <a href="{{intervention.id}}/action-plan" class="govuk-link">View</a></td>
                     </tr>
                   </tbody>
               </table>
@@ -293,10 +293,52 @@
                 <p class="govuk-body">No sessions have been scheduled.</p>
               {% endif %}
 
+
               <h2 class="govuk-heading-m">End of service report</h2>
+              
+              {% if intervention.monitor.completed and intervention.monitor.completed %}
+              <p class="govuk-body">
+                This is the end of service report created by the service provider. When it is submitted by the service provider, you will be able to read it.
+              </p>
+
+              <table class="govuk-table">
+                <thead class="govuk-table__head">
+                  <tr class="govuk-table__row">
+                    <th scope="col" class="govuk-table__header">Caseworker</th>
+                    <th scope="col" class="govuk-table__header">Status</th>
+                    <th scope="col" class="govuk-table__header">Action</th>
+                  </tr>
+                </thead>
+
+                <tbody class="govuk-table__body">
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">{{ intervention.assignedCaseworker}}</td>
+                    <td class="govuk-table__cell">
+                      {% if intervention.monitor.endOfServiceReportSubmitted %}
+                        <strong class="govuk-tag">
+                          completed
+                        </strong>
+                      {% else %}
+                        <strong class="govuk-tag govuk-tag--grey">
+                          not started
+                        </strong>
+                      {% endif %}
+                    </td>
+                    <td class="govuk-table__cell">
+                      {% if intervention.monitor.endOfServiceReportSubmitted %}
+                        <a href="{{intervention.id}}/end-of-service-report" class="govuk-link">View</a>
+                      {% else %}
+                      {% endif %}
+                    </td>
+                    </tr>
+                </tbody>
+              </table>
+
+              {% else %}
               <p class="govuk-body">
                 An intervention ready for an end of service assessment will appear below once all the post-session feedback forms of the intervention are completed.
               </p>
+              {% endif %}
             </div>
 
             <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="case-notes">


### PR DESCRIPTION
## Changes in this PR:
- Added the end of service report template to `Monitor`
- Added a flag `endOfServiceReportSubmitted` to the logic
- Updated conditions on the end of service report section in the `intervention` template  

## Screenshots of UI changes:

### When sessions are not all completed
![screencapture-localhost-3001-sprint-7-monitor-cases-NR0005-interventions-0-2020-10-23-13_53_42](https://user-images.githubusercontent.com/6421298/97011414-8ba60100-153e-11eb-9644-ef4cbc34a94d.png)

### When all sessions are completed but report not ready
![screencapture-localhost-3001-sprint-7-monitor-cases-NR0015-interventions-0-2020-10-23-13_56_10](https://user-images.githubusercontent.com/6421298/97011410-8a74d400-153e-11eb-8dd5-53d2db5f9a4d.png)

### When all sessions are completed and report is ready
![screencapture-localhost-3001-sprint-7-monitor-cases-NR0009-interventions-0-2020-10-23-13_53_51](https://user-images.githubusercontent.com/6421298/97011412-8b0d6a80-153e-11eb-87bc-09d61be0c94c.png)

### End of service report
![screencapture-localhost-3001-sprint-7-monitor-cases-NR0009-interventions-0-end-of-service-report-2020-10-23-13_56_19](https://user-images.githubusercontent.com/6421298/97011398-8648b680-153e-11eb-9795-99c57a1b93e2.png)