### PR TITLE
Fix monitor case stage logic

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -2007,7 +2007,7 @@ module.exports = {
             monitor: {
               actionPlanSubmitted: false,
               actionPlanApproved: false,
-              assigned: true,
+              assigned: false,
               inProgress: false,
               initialAssessmentScheduled: true,
               initialAssessmentDate: "10/02/2020",

--- a/app/routes/sprint-7/monitorRoutes.js
+++ b/app/routes/sprint-7/monitorRoutes.js
@@ -18,57 +18,122 @@ const groupBy = (items, key, sortingFunction = sortByDateAndTime) =>
 
 router.get("/cases", (req, res) => {
   const referrals = req.session.data.sprint7.referrals;
-  const referralsWithSomeUnassigned = referrals.filter((referral) => {
-    return referral.interventions.some(
-      (intervention) => !intervention.monitor.assigned
-    );
-  });
 
-  const referralsAwaitingAssessment = referrals.filter((referral) => {
-    return referral.interventions.some(
-      (intervention) =>
-        intervention.monitor.assigned &&
-        !intervention.monitor.actionPlanSubmitted
-    );
-  });
+  const unassignedReferrals = referrals
+    .filter((referral) =>
+      referral.interventions.some(
+        (intervention) => !intervention.monitor.assigned
+      )
+    )
+    .map((referral) => {
+      return {
+        ...referral,
+        interventions: referral.interventions.filter(
+          (intervention) => !intervention.monitor.assigned
+        ),
+      };
+    });
 
-  const referralsWithActionPlan = referrals.filter((referral) => {
-    return referral.interventions.some(
-      (intervention) =>
-        intervention.monitor.actionPlanSubmitted &&
-        !intervention.monitor.inProgress &&
-        !intervention.monitor.completed
-    );
-  });
-  const referralsInProgress = referrals.filter((referral) => {
-    return referral.interventions.some(
-      (intervention) =>
-        intervention.monitor.inProgress &&
-        !intervention.monitor.overdue &&
-        !intervention.monitor.completed
-    );
-  });
+  const referralsAwaitingAssessment = referrals
+    .filter((referral) =>
+      referral.interventions.some(
+        (intervention) =>
+          intervention.monitor.assigned &&
+          !intervention.monitor.actionPlanSubmitted
+      )
+    )
+    .map((referral) => {
+      return {
+        ...referral,
+        interventions: referral.interventions.filter(
+          (intervention) =>
+            intervention.monitor.assigned &&
+            !intervention.monitor.actionPlanSubmitted
+        ),
+      };
+    });
 
-  const referralsAwaitingPostSessionQuestionnaire = referrals.filter(
-    (referral) => {
-      return referral.interventions.some(
+  const referralsWithActionPlan = referrals
+    .filter((referral) =>
+      referral.interventions.some(
+        (intervention) =>
+          intervention.monitor.actionPlanSubmitted &&
+          !intervention.monitor.inProgress &&
+          !intervention.monitor.completed
+      )
+    )
+    .map((referral) => {
+      return {
+        ...referral,
+        interventions: referral.interventions.filter(
+          (intervention) =>
+            intervention.monitor.actionPlanSubmitted &&
+            !intervention.monitor.inProgress &&
+            !intervention.monitor.completed
+        ),
+      };
+    });
+
+  const referralsInProgress = referrals
+    .filter((referral) =>
+      referral.interventions.some(
+        (intervention) =>
+          intervention.monitor.inProgress &&
+          !intervention.monitor.overdue &&
+          !intervention.monitor.completed
+      )
+    )
+    .map((referral) => {
+      return {
+        ...referral,
+        interventions: referral.interventions.filter(
+          (intervention) =>
+            intervention.monitor.inProgress &&
+            !intervention.monitor.overdue &&
+            !intervention.monitor.completed
+        ),
+      };
+    });
+
+  const referralsAwaitingPostSessionQuestionnaire = referrals
+    .filter((referral) =>
+      referral.interventions.some(
         (intervention) =>
           intervention.monitor.inProgress &&
           intervention.monitor.awaitingPostSessionQuestionnaire &&
           !intervention.monitor.completed
-      );
-    }
-  );
+      )
+    )
+    .map((referral) => {
+      return {
+        ...referral,
+        interventions: referral.interventions.filter(
+          (intervention) =>
+            intervention.monitor.inProgress &&
+            intervention.monitor.awaitingPostSessionQuestionnaire &&
+            !intervention.monitor.completed
+        ),
+      };
+    });
 
-  const referralsCompleted = referrals.filter((referral) => {
-    return referral.interventions.some(
-      (intervention) => intervention.monitor.completed
-    );
-  });
+  const referralsCompleted = referrals
+    .filter((referral) =>
+      referral.interventions.some(
+        (intervention) => intervention.monitor.completed
+      )
+    )
+    .map((referral) => {
+      return {
+        ...referral,
+        interventions: referral.interventions.filter(
+          (intervention) => intervention.monitor.completed
+        ),
+      };
+    });
 
   res.render("sprint-7/monitor/cases", {
     referrals: req.session.data.sprint7.referrals,
-    referralsWithSomeUnassigned: referralsWithSomeUnassigned,
+    unassignedReferrals: unassignedReferrals,
     referralsAwaitingAssessment: referralsAwaitingAssessment,
     referralsWithActionPlan: referralsWithActionPlan,
     referralsInProgress: referralsInProgress,

--- a/app/routes/sprint-7/monitorRoutes.js
+++ b/app/routes/sprint-7/monitorRoutes.js
@@ -79,6 +79,7 @@ router.get("/cases", (req, res) => {
       referral.interventions.some(
         (intervention) =>
           intervention.monitor.inProgress &&
+          !intervention.monitor.awaitingPostSessionQuestionnaire &&
           !intervention.monitor.overdue &&
           !intervention.monitor.completed
       )
@@ -89,6 +90,7 @@ router.get("/cases", (req, res) => {
         interventions: referral.interventions.filter(
           (intervention) =>
             intervention.monitor.inProgress &&
+            !intervention.monitor.awaitingPostSessionQuestionnaire &&
             !intervention.monitor.overdue &&
             !intervention.monitor.completed
         ),

--- a/app/views/sprint-7/monitor/includes/cases/by-stage.html
+++ b/app/views/sprint-7/monitor/includes/cases/by-stage.html
@@ -25,13 +25,13 @@
   <div class="govuk-tabs__panel" id="referral">
     {% set referralsToDisplay = unassignedReferrals %}
     <h2 class="govuk-heading-m">
-      Awaiting a caseworker to be assigned (2)
+      Awaiting a caseworker to be assigned ({{ referralsToDisplay | length }})
     </h2>
     {% include "./table.html"%}
 
     {% set referralsToDisplay = referralsAwaitingAssessment %}
     <h2 class="govuk-heading-m">
-      Awaiting assessment (2)
+      Awaiting assessment ({{ referralsToDisplay | length }})
     </h2>
     {% include "./table.html"%}
   </div>
@@ -44,13 +44,13 @@
   <div class="govuk-tabs__panel" id="intervention-progress">
     {% set referralsToDisplay = referralsInProgress %}
     <h2 class="govuk-heading-m">
-      Intervention in progress (6)
+      Intervention in progress ({{ referralsToDisplay | length }})
     </h2>
     {% include "./table.html"%}
 
     <h2 class="govuk-heading-m">
     {% set referralsToDisplay = referralsAwaitingPostSessionQuestionnaire %}
-      Post-session questionnaire to complete (3)
+      Post-session questionnaire to complete ({{ referralsToDisplay | length }})
     </h2>
     {% include "./table.html"%}
   </div>

--- a/app/views/sprint-7/monitor/includes/cases/by-stage.html
+++ b/app/views/sprint-7/monitor/includes/cases/by-stage.html
@@ -23,7 +23,7 @@
   </ul>
 
   <div class="govuk-tabs__panel" id="referral">
-    {% set referralsToDisplay = referralsWithSomeUnassigned %}
+    {% set referralsToDisplay = unassignedReferrals %}
     <h2 class="govuk-heading-m">
       Awaiting a caseworker to be assigned (2)
     </h2>


### PR DESCRIPTION
## Changes in this PR

Before this change, a referral's interventions were all grouped together
in the "stages" table (even if only one intervention matched the stage,
the other ones would be shown in that stage due to incorrect logic)

This manually sets the interventions on a new object, removing those
that don't qualify for the stage of an intervention.

This is currently pretty gnarly logic, but it felt quicker than changing
the underlying data when time is quite short. I originally wrote it as a
reduce to avoid `filter`ing and `mapping` but this looked even less
readable...

This also fixes the counts on stages and makes them dynamic.