### PR TITLE
Fix monitor intervention counts in table

### DIFF
--- a/app/routes/sprint-7/monitorRoutes.js
+++ b/app/routes/sprint-7/monitorRoutes.js
@@ -315,7 +315,9 @@ router.post(
 
     intervention.monitor.actionPlanApproved = actionPlanApproved;
 
-    res.redirect(`/sprint-7/monitor/cases/${referralNumber}/interventions/${interventionId}`);
+    res.redirect(
+      `/sprint-7/monitor/cases/${referralNumber}/interventions/${interventionId}`
+    );
   }
 );
 
@@ -357,7 +359,9 @@ router.get(
         break;
     }
 
-    res.redirect(`/sprint-7/monitor/cases/${req.params.referralNumber}/interventions/${req.params.interventionId}`);
+    res.redirect(
+      `/sprint-7/monitor/cases/${req.params.referralNumber}/interventions/${req.params.interventionId}`
+    );
   }
 );
 

--- a/app/routes/sprint-7/monitorRoutes.js
+++ b/app/routes/sprint-7/monitorRoutes.js
@@ -22,14 +22,14 @@ router.get("/cases", (req, res) => {
   const unassignedReferrals = referrals
     .filter((referral) =>
       referral.interventions.some(
-        (intervention) => !intervention.monitor.assigned
+        (intervention) => !intervention.assignedCaseworker
       )
     )
     .map((referral) => {
       return {
         ...referral,
         interventions: referral.interventions.filter(
-          (intervention) => !intervention.monitor.assigned
+          (intervention) => !intervention.assignedCaseworker
         ),
       };
     });
@@ -38,7 +38,7 @@ router.get("/cases", (req, res) => {
     .filter((referral) =>
       referral.interventions.some(
         (intervention) =>
-          intervention.monitor.assigned &&
+          intervention.assignedCaseworker &&
           !intervention.monitor.actionPlanSubmitted
       )
     )
@@ -47,7 +47,7 @@ router.get("/cases", (req, res) => {
         ...referral,
         interventions: referral.interventions.filter(
           (intervention) =>
-            intervention.monitor.assigned &&
+            intervention.assignedCaseworker &&
             !intervention.monitor.actionPlanSubmitted
         ),
       };
@@ -334,8 +334,7 @@ router.get(
 
     switch (toState) {
       case "assignedCaseworker":
-        intervention.assignedCaseworker = "Jenny Thompson";
-        intervention.monitor.assigned = true;
+        intervention.assignedCaseworker = "Liam Johnson";
         break;
       case "initialAssessmentCompleted":
         intervention.monitor.initialAssessmentCompleted = true;

--- a/app/routes/sprint-7/monitorRoutes.js
+++ b/app/routes/sprint-7/monitorRoutes.js
@@ -133,8 +133,12 @@ router.get("/cases", (req, res) => {
       };
     });
 
+  const count = (referrals) =>
+    referrals.flatMap((referral) => referral.interventions).length;
+
   res.render("sprint-7/monitor/cases", {
     referrals: req.session.data.sprint7.referrals,
+    count: count,
     unassignedReferrals: unassignedReferrals,
     referralsAwaitingAssessment: referralsAwaitingAssessment,
     referralsWithActionPlan: referralsWithActionPlan,

--- a/app/views/sprint-7/monitor/includes/cases/by-stage.html
+++ b/app/views/sprint-7/monitor/includes/cases/by-stage.html
@@ -25,13 +25,13 @@
   <div class="govuk-tabs__panel" id="referral">
     {% set referralsToDisplay = unassignedReferrals %}
     <h2 class="govuk-heading-m">
-      Awaiting a caseworker to be assigned ({{ referralsToDisplay | length }})
+      Awaiting a caseworker to be assigned ({{ count(referralsToDisplay) }})
     </h2>
     {% include "./table.html"%}
 
     {% set referralsToDisplay = referralsAwaitingAssessment %}
     <h2 class="govuk-heading-m">
-      Awaiting assessment ({{ referralsToDisplay | length }})
+      Awaiting assessment ({{ count(referralsToDisplay) }})
     </h2>
     {% include "./table.html"%}
   </div>
@@ -44,13 +44,13 @@
   <div class="govuk-tabs__panel" id="intervention-progress">
     {% set referralsToDisplay = referralsInProgress %}
     <h2 class="govuk-heading-m">
-      Intervention in progress ({{ referralsToDisplay | length }})
+      Intervention in progress ({{ count(referralsToDisplay) }})
     </h2>
     {% include "./table.html"%}
 
     <h2 class="govuk-heading-m">
     {% set referralsToDisplay = referralsAwaitingPostSessionQuestionnaire %}
-      Post-session questionnaire to complete ({{ referralsToDisplay | length }})
+      Post-session questionnaire to complete ({{ count(referralsToDisplay) }})
     </h2>
     {% include "./table.html"%}
   </div>


### PR DESCRIPTION
The table was previously counting the number of referrals, which didn't line up with the number of interventions being displayed in the table and looked wrong.

Also removes reliance on pure `monitor` data, as some data can be changed in the Record and Receive process and was getting out of sync.

